### PR TITLE
Add missing dependency for bignumber.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@web3-react/injected-connector": "^6.0.7",
         "@web3-react/walletconnect-connector": "^6.1.9",
         "@web3-react/walletlink-connector": "^6.1.9",
+        "bignumber.js": "^9.1.1",
         "dayjs": "^1.11.6",
         "embla-carousel-react": "^5.0.1",
         "graphql-request": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@web3-react/injected-connector": "^6.0.7",
     "@web3-react/walletconnect-connector": "^6.1.9",
     "@web3-react/walletlink-connector": "^6.1.9",
+    "bignumber.js": "^9.1.1",
     "dayjs": "^1.11.6",
     "embla-carousel-react": "^5.0.1",
     "graphql-request": "^5.0.0",


### PR DESCRIPTION
https://github.com/liteflow-labs/starter-kit/pull/89 added a new hook with a new dependency to `bignumber.js` that was not added in the package.json. Since this library will not be added by the `@nft/hooks` package anymore then this will create issues