### PR TITLE
Migrate node env to lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
Update github actions to use the latest LTS version of node v18