### PR TITLE
Remove trello link from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,5 @@
 ### Project organization
 
-- Trello card: <!-- add link to trello card if any -->
 - Closes <!-- add link to issue that this PR fixes if any -->
 - Related <!-- add link to related issue if any -->
 - Dependant on <!-- add link to dependant PR if any -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,5 @@
 
 ### Checklist
 
+- [ ] Base branch of the PR is `dev`
 - [ ] Update docs if necessary <!-- Docs in https://github.com/liteflow-labs/liteflow-js/tree/main/docs/pages/starter-kit -->


### PR DESCRIPTION
Remove trello link from PR template


---

EDIT: also bring modif from https://github.com/liteflow-labs/starter-kit/pull/127. Those modif are only on the dev branch but the pr template file is read from the main branch