### PR TITLE
Paginate results for owners

### DIFF
--- a/components/Pagination/Pagination.tsx
+++ b/components/Pagination/Pagination.tsx
@@ -4,13 +4,23 @@ import { IoChevronForward } from '@react-icons/all-files/io5/IoChevronForward'
 import { useMemo } from 'react'
 import Select from '../Select/Select'
 
-export type IProp = {
+type PropWithSelector = {
+  hideSelectors?: false | undefined
   limits: number[]
+  onLimitChange: (limit: string) => void
+}
+
+type PropWithoutSelector = {
+  hideSelectors: true
+  limits?: never
+  onLimitChange?: never
+}
+
+export type IProp = {
   limit: number
   page: number
   total?: number
   onPageChange: (page: number) => void
-  onLimitChange: (limit: string) => void
   result: {
     label: string
     caption: (context: {
@@ -20,18 +30,14 @@ export type IProp = {
     }) => string | JSX.Element
     pages: (context: { total: number }) => string | JSX.Element
   }
-  simple?: boolean
-}
+} & (PropWithSelector | PropWithoutSelector)
 
 export default function Pagination({
-  onPageChange,
-  onLimitChange,
-  total,
-  page = 1,
-  limits,
   limit,
+  onPageChange,
+  page,
   result,
-  simple,
+  total,
   ...props
 }: IProp): JSX.Element {
   const goTo = (newPage: number) => {
@@ -51,7 +57,7 @@ export default function Pagination({
   if (!total) return <></>
   return (
     <Flex
-      direction={{ base: simple ? 'row' : 'column', md: 'row' }}
+      direction={{ base: props.hideSelectors ? 'row' : 'column', md: 'row' }}
       align="center"
       justify={{ base: 'center', sm: 'space-between' }}
       w="full"
@@ -64,13 +70,13 @@ export default function Pagination({
         w={{ base: 'full', sm: 'auto' }}
         direction={{ base: 'column', sm: 'row' }}
       >
-        {!simple && (
+        {!props.hideSelectors && (
           <Select
             selectWidth={24}
             label={result.label}
             name="limit"
-            onChange={(e: any) => onLimitChange(e)}
-            choices={limits.map((x) => ({
+            onChange={(e: any) => props.onLimitChange(e)}
+            choices={props.limits.map((x) => ({
               value: x.toString(),
               label: x.toString(),
             }))}
@@ -99,7 +105,7 @@ export default function Pagination({
         gap={6}
         aria-label="Pagination"
       >
-        {!simple && (
+        {!props.hideSelectors && (
           <Flex align="center" gap={3}>
             <Select
               selectWidth={24}

--- a/components/Pagination/Pagination.tsx
+++ b/components/Pagination/Pagination.tsx
@@ -20,6 +20,7 @@ export type IProp = {
     }) => string | JSX.Element
     pages: (context: { total: number }) => string | JSX.Element
   }
+  simple?: boolean
 }
 
 export default function Pagination({
@@ -30,6 +31,7 @@ export default function Pagination({
   limits,
   limit,
   result,
+  simple,
   ...props
 }: IProp): JSX.Element {
   const goTo = (newPage: number) => {
@@ -49,7 +51,7 @@ export default function Pagination({
   if (!total) return <></>
   return (
     <Flex
-      direction={{ base: 'column', md: 'row' }}
+      direction={{ base: simple ? 'row' : 'column', md: 'row' }}
       align="center"
       justify={{ base: 'center', sm: 'space-between' }}
       w="full"
@@ -62,18 +64,20 @@ export default function Pagination({
         w={{ base: 'full', sm: 'auto' }}
         direction={{ base: 'column', sm: 'row' }}
       >
-        <Select
-          selectWidth={24}
-          label={result.label}
-          name="limit"
-          onChange={(e: any) => onLimitChange(e)}
-          choices={limits.map((x) => ({
-            value: x.toString(),
-            label: x.toString(),
-          }))}
-          value={limit.toString()}
-          inlineLabel
-        />
+        {!simple && (
+          <Select
+            selectWidth={24}
+            label={result.label}
+            name="limit"
+            onChange={(e: any) => onLimitChange(e)}
+            choices={limits.map((x) => ({
+              value: x.toString(),
+              label: x.toString(),
+            }))}
+            value={limit.toString()}
+            inlineLabel
+          />
+        )}
         <Text
           as="span"
           variant="text-sm"
@@ -95,23 +99,25 @@ export default function Pagination({
         gap={6}
         aria-label="Pagination"
       >
-        <Flex align="center" gap={3}>
-          <Select
-            selectWidth={24}
-            name="page"
-            onChange={(e: any) => goTo(parseInt(e.toString(), 10))}
-            choices={Array.from({ length: totalPage }, (_, i) => i + 1).map(
-              (x) => ({
-                value: x.toString(),
-                label: x.toString(),
-              }),
-            )}
-            value={page.toString()}
-          />
-          <Text as="p" variant="text-sm" color="gray.500" w="full">
-            {result.pages({ total: totalPage })}
-          </Text>
-        </Flex>
+        {!simple && (
+          <Flex align="center" gap={3}>
+            <Select
+              selectWidth={24}
+              name="page"
+              onChange={(e: any) => goTo(parseInt(e.toString(), 10))}
+              choices={Array.from({ length: totalPage }, (_, i) => i + 1).map(
+                (x) => ({
+                  value: x.toString(),
+                  label: x.toString(),
+                }),
+              )}
+              value={page.toString()}
+            />
+            <Text as="p" variant="text-sm" color="gray.500" w="full">
+              {result.pages({ total: totalPage })}
+            </Text>
+          </Flex>
+        )}
         <Flex align="center" gap={4}>
           <IconButton
             variant="outline"

--- a/components/Token/Header.tsx
+++ b/components/Token/Header.tsx
@@ -32,7 +32,7 @@ export type Props = {
   currencies: SaleDetailProps['currencies']
   creator: TokenAssetProps['creator']
   owners: TokenAssetProps['owners']
-  ownerCount: TokenAssetProps['ownerCount']
+  numberOfOwners: TokenAssetProps['numberOfOwners']
   auction: SaleDetailProps['auction']
   bestBid: SaleDetailProps['bestBid']
   sales: SaleDetailProps['directSales']
@@ -49,7 +49,7 @@ const TokenHeader: VFC<Props> = ({
   currencies,
   creator,
   owners,
-  ownerCount,
+  numberOfOwners,
   auction,
   bestBid,
   sales,
@@ -115,7 +115,7 @@ const TokenHeader: VFC<Props> = ({
           assetId={asset.id}
           creator={creator}
           owners={owners}
-          ownerCount={ownerCount}
+          numberOfOwners={numberOfOwners}
           saleSupply={asset.saleSupply}
           standard={asset.collection.standard}
           totalSupply={asset.totalSupply}

--- a/components/Token/Header.tsx
+++ b/components/Token/Header.tsx
@@ -9,7 +9,7 @@ import type { Props as SaleDetailProps } from '../Sales/Detail'
 import SaleDetail from '../Sales/Detail'
 import TokenMedia from '../Token/Media'
 import type { Props as TokenAssetProps } from '../Token/Metadata'
-import TokenAsset from '../Token/Metadata'
+import TokenMetadata from '../Token/Metadata'
 
 export type Props = {
   blockExplorer: BlockExplorer
@@ -32,6 +32,7 @@ export type Props = {
   currencies: SaleDetailProps['currencies']
   creator: TokenAssetProps['creator']
   owners: TokenAssetProps['owners']
+  ownerCount: TokenAssetProps['ownerCount']
   auction: SaleDetailProps['auction']
   bestBid: SaleDetailProps['bestBid']
   sales: SaleDetailProps['directSales']
@@ -48,6 +49,7 @@ const TokenHeader: VFC<Props> = ({
   currencies,
   creator,
   owners,
+  ownerCount,
   auction,
   bestBid,
   sales,
@@ -109,9 +111,10 @@ const TokenHeader: VFC<Props> = ({
             {asset.name}
           </Heading>
         </Stack>
-        <TokenAsset
+        <TokenMetadata
           creator={creator}
           owners={owners}
+          ownerCount={ownerCount}
           saleSupply={asset.saleSupply}
           standard={asset.collection.standard}
           totalSupply={asset.totalSupply}

--- a/components/Token/Header.tsx
+++ b/components/Token/Header.tsx
@@ -112,6 +112,7 @@ const TokenHeader: VFC<Props> = ({
           </Heading>
         </Stack>
         <TokenMetadata
+          assetId={asset.id}
           creator={creator}
           owners={owners}
           ownerCount={ownerCount}

--- a/components/Token/Metadata.tsx
+++ b/components/Token/Metadata.tsx
@@ -9,6 +9,7 @@ import OwnersModal from './Owners/Modal'
 import Supply from './Supply'
 
 export type Props = {
+  assetId: string
   standard: Standard
   creator:
     | {
@@ -31,6 +32,7 @@ export type Props = {
 }
 
 const TokenMetadata: VFC<Props> = ({
+  assetId,
   standard,
   creator,
   owners,
@@ -73,6 +75,7 @@ const TokenMetadata: VFC<Props> = ({
             {t('token.metadata.owners')}
           </Heading>
           <OwnersModal
+            assetId={assetId}
             ownersPreview={owners}
             ownerCount={ownerCount}
           />

--- a/components/Token/Metadata.tsx
+++ b/components/Token/Metadata.tsx
@@ -25,6 +25,7 @@ export type Props = {
     verified: boolean
     quantity: string
   }[]
+  ownerCount: number
   saleSupply: BigNumber
   totalSupply: BigNumber | null | undefined
 }
@@ -33,6 +34,7 @@ const TokenMetadata: VFC<Props> = ({
   standard,
   creator,
   owners,
+  ownerCount,
   saleSupply,
   totalSupply,
 }) => {
@@ -52,7 +54,7 @@ const TokenMetadata: VFC<Props> = ({
           />
         </Stack>
       )}
-      {owners.length === 1 && owners[0] && (
+      {ownerCount === 1 && owners[0] && (
         <Stack spacing={3}>
           <Heading as="h5" variant="heading3" color="gray.500">
             {t('token.metadata.owner')}
@@ -65,12 +67,15 @@ const TokenMetadata: VFC<Props> = ({
           />
         </Stack>
       )}
-      {owners.length > 1 && (
+      {ownerCount > 1 && (
         <Stack spacing={3}>
           <Heading as="h5" variant="heading3" color="gray.500">
             {t('token.metadata.owners')}
           </Heading>
-          <OwnersModal owners={owners} />
+          <OwnersModal
+            ownersPreview={owners}
+            ownerCount={ownerCount}
+          />
         </Stack>
       )}
       {standard === 'ERC721' && (

--- a/components/Token/Metadata.tsx
+++ b/components/Token/Metadata.tsx
@@ -26,7 +26,7 @@ export type Props = {
     verified: boolean
     quantity: string
   }[]
-  ownerCount: number
+  numberOfOwners: number
   saleSupply: BigNumber
   totalSupply: BigNumber | null | undefined
 }
@@ -36,7 +36,7 @@ const TokenMetadata: VFC<Props> = ({
   standard,
   creator,
   owners,
-  ownerCount,
+  numberOfOwners,
   saleSupply,
   totalSupply,
 }) => {
@@ -56,7 +56,7 @@ const TokenMetadata: VFC<Props> = ({
           />
         </Stack>
       )}
-      {ownerCount === 1 && owners[0] && (
+      {numberOfOwners === 1 && owners[0] && (
         <Stack spacing={3}>
           <Heading as="h5" variant="heading3" color="gray.500">
             {t('token.metadata.owner')}
@@ -69,7 +69,7 @@ const TokenMetadata: VFC<Props> = ({
           />
         </Stack>
       )}
-      {ownerCount > 1 && (
+      {numberOfOwners > 1 && (
         <Stack spacing={3}>
           <Heading as="h5" variant="heading3" color="gray.500">
             {t('token.metadata.owners')}
@@ -77,7 +77,7 @@ const TokenMetadata: VFC<Props> = ({
           <OwnersModal
             assetId={assetId}
             ownersPreview={owners}
-            ownerCount={ownerCount}
+            numberOfOwners={numberOfOwners}
           />
         </Stack>
       )}

--- a/components/Token/Owners/Modal.tsx
+++ b/components/Token/Owners/Modal.tsx
@@ -103,7 +103,7 @@ const OwnersModal: VFC<Props> = ({
                       <ListItem
                         key={index}
                         image={<SkeletonCircle />}
-                        label={<SkeletonText noOfLines={2} />}
+                        label={<SkeletonText noOfLines={2} width="32" />}
                       />
                     ))
                 : data?.ownerships?.nodes

--- a/components/Token/Owners/Modal.tsx
+++ b/components/Token/Owners/Modal.tsx
@@ -33,10 +33,14 @@ export type Props = {
     verified: boolean
     quantity: string
   }[]
-  ownerCount: number
+  numberOfOwners: number
 }
 
-const OwnersModal: VFC<Props> = ({ assetId, ownersPreview, ownerCount }) => {
+const OwnersModal: VFC<Props> = ({
+  assetId,
+  ownersPreview,
+  numberOfOwners,
+}) => {
   const { t } = useTranslation('components')
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [page, setPage] = useState(1)
@@ -55,7 +59,7 @@ const OwnersModal: VFC<Props> = ({ assetId, ownersPreview, ownerCount }) => {
     <>
       <OwnersModalActivator
         owners={ownersPreview}
-        ownerCount={ownerCount}
+        numberOfOwners={numberOfOwners}
         onClick={onOpen}
       />
       <Modal
@@ -81,7 +85,7 @@ const OwnersModal: VFC<Props> = ({ assetId, ownersPreview, ownerCount }) => {
                 px={2.5}
               >
                 <Text as="span" variant="caption" color="brand.500">
-                  {ownerCount}
+                  {numberOfOwners}
                 </Text>
               </Flex>
             </Flex>

--- a/components/Token/Owners/Modal.tsx
+++ b/components/Token/Owners/Modal.tsx
@@ -45,7 +45,7 @@ const OwnersModal: VFC<Props> = ({
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [page, setPage] = useState(1)
   const [limit, setLimit] = useState(environment.PAGINATION_LIMIT)
-  const { data, loading } = useFetchOwnersQuery({
+  const { data, loading, previousData } = useFetchOwnersQuery({
     variables: {
       assetId,
       limit,
@@ -119,7 +119,10 @@ const OwnersModal: VFC<Props> = ({
               limit={environment.PAGINATION_LIMIT}
               limits={[environment.PAGINATION_LIMIT]} //, 24, 36, 48]}
               page={page}
-              total={data?.ownerships?.totalCount}
+              total={
+                data?.ownerships?.totalCount ||
+                previousData?.ownerships?.totalCount
+              }
               onPageChange={setPage}
               simple
               onLimitChange={(limit) => setLimit(parseInt(limit, 10))}

--- a/components/Token/Owners/Modal.tsx
+++ b/components/Token/Owners/Modal.tsx
@@ -17,21 +17,26 @@ import OwnersModalActivator from './ModalActivator'
 import OwnersModalItem from './ModalItem'
 
 export type Props = {
-  owners: {
+  ownersPreview: {
     address: string
     image: string | null | undefined
     name: string | null | undefined
     verified: boolean
     quantity: string
   }[]
+  ownerCount: number
 }
 
-const OwnersModal: VFC<Props> = ({ owners }) => {
+const OwnersModal: VFC<Props> = ({ assetId, ownersPreview, ownerCount }) => {
   const { t } = useTranslation('components')
   const { isOpen, onOpen, onClose } = useDisclosure()
   return (
     <>
-      <OwnersModalActivator owners={owners} onClick={onOpen} />
+      <OwnersModalActivator
+        owners={ownersPreview}
+        ownerCount={ownerCount}
+        onClick={onOpen}
+      />
       <Modal
         isOpen={isOpen}
         onClose={onClose}

--- a/components/Token/Owners/Modal.tsx
+++ b/components/Token/Owners/Modal.tsx
@@ -1,4 +1,5 @@
 import {
+  chakra,
   Flex,
   Modal,
   ModalBody,
@@ -7,16 +8,24 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  SkeletonCircle,
+  SkeletonText,
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
+import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
-import { VFC } from 'react'
-import List from '../../List/List'
+import { useEffect, useState, VFC } from 'react'
+import { convertOwnership } from '../../../convert'
+import environment from '../../../environment'
+import { useFetchOwnersQuery } from '../../../graphql'
+import List, { ListItem } from '../../List/List'
+import Pagination from '../../Pagination/Pagination'
 import OwnersModalActivator from './ModalActivator'
 import OwnersModalItem from './ModalItem'
 
 export type Props = {
+  assetId: string
   ownersPreview: {
     address: string
     image: string | null | undefined
@@ -30,6 +39,18 @@ export type Props = {
 const OwnersModal: VFC<Props> = ({ assetId, ownersPreview, ownerCount }) => {
   const { t } = useTranslation('components')
   const { isOpen, onOpen, onClose } = useDisclosure()
+  const [page, setPage] = useState(1)
+  const [limit, setLimit] = useState(environment.PAGINATION_LIMIT)
+  const { data, loading } = useFetchOwnersQuery({
+    variables: {
+      assetId,
+      limit,
+      offset: (page - 1) * limit,
+    },
+  })
+  // Reset pagination when the limit change or the modal visibility changes
+  useEffect(() => setPage(1), [limit, isOpen])
+  const ChakraPagination = chakra(Pagination)
   return (
     <>
       <OwnersModalActivator
@@ -60,20 +81,61 @@ const OwnersModal: VFC<Props> = ({ assetId, ownersPreview, ownerCount }) => {
                 px={2.5}
               >
                 <Text as="span" variant="caption" color="brand.500">
-                  {owners.length}
+                  {ownerCount}
                 </Text>
               </Flex>
             </Flex>
           </ModalHeader>
           <ModalCloseButton />
-          <ModalBody>
+          <ModalBody
+            maxHeight={{ base: '', md: 'lg' }}
+            minHeight={{ base: '', md: 'lg' }}
+          >
             <List>
-              {owners.map((owner) => (
-                <OwnersModalItem key={owner.address} {...owner} />
-              ))}
+              {loading
+                ? new Array(limit)
+                    .fill(0)
+                    .map((_, index) => (
+                      <ListItem
+                        key={index}
+                        image={<SkeletonCircle />}
+                        label={<SkeletonText noOfLines={2} />}
+                      />
+                    ))
+                : data?.ownerships?.nodes
+                    .map(convertOwnership)
+                    .map((owner) => (
+                      <OwnersModalItem key={owner.address} {...owner} />
+                    ))}
             </List>
           </ModalBody>
-          <ModalFooter as="div" />
+          <ModalFooter>
+            <ChakraPagination
+              pt="4"
+              limit={environment.PAGINATION_LIMIT}
+              limits={[environment.PAGINATION_LIMIT]} //, 24, 36, 48]}
+              page={page}
+              total={data?.ownerships?.totalCount}
+              onPageChange={setPage}
+              simple
+              onLimitChange={(limit) => setLimit(parseInt(limit, 10))}
+              result={{
+                label: t('pagination.result.label'),
+                caption: (props) => (
+                  <Trans
+                    ns="templates"
+                    i18nKey="pagination.result.caption"
+                    values={props}
+                    components={[
+                      <Text as="span" color="brand.black" key="text" />,
+                    ]}
+                  />
+                ),
+                pages: (props) =>
+                  t('pagination.result.pages', { count: props.total }),
+              }}
+            />
+          </ModalFooter>
         </ModalContent>
       </Modal>
     </>

--- a/components/Token/Owners/Modal.tsx
+++ b/components/Token/Owners/Modal.tsx
@@ -17,7 +17,6 @@ import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { useEffect, useState, VFC } from 'react'
 import { convertOwnership } from '../../../convert'
-import environment from '../../../environment'
 import { useFetchOwnersQuery } from '../../../graphql'
 import List, { ListItem } from '../../List/List'
 import Pagination from '../../Pagination/Pagination'
@@ -36,6 +35,8 @@ export type Props = {
   numberOfOwners: number
 }
 
+const OwnerPaginationLimit = 8
+
 const OwnersModal: VFC<Props> = ({
   assetId,
   ownersPreview,
@@ -44,16 +45,15 @@ const OwnersModal: VFC<Props> = ({
   const { t } = useTranslation('components')
   const { isOpen, onOpen, onClose } = useDisclosure()
   const [page, setPage] = useState(1)
-  const [limit, setLimit] = useState(environment.PAGINATION_LIMIT)
   const { data, loading, previousData } = useFetchOwnersQuery({
     variables: {
       assetId,
-      limit,
-      offset: (page - 1) * limit,
+      limit: OwnerPaginationLimit,
+      offset: (page - 1) * OwnerPaginationLimit,
     },
   })
   // Reset pagination when the limit change or the modal visibility changes
-  useEffect(() => setPage(1), [limit, isOpen])
+  useEffect(() => setPage(1), [isOpen])
   const ChakraPagination = chakra(Pagination)
   return (
     <>
@@ -97,7 +97,7 @@ const OwnersModal: VFC<Props> = ({
           >
             <List>
               {loading
-                ? new Array(limit)
+                ? new Array(OwnerPaginationLimit)
                     .fill(0)
                     .map((_, index) => (
                       <ListItem
@@ -116,16 +116,14 @@ const OwnersModal: VFC<Props> = ({
           <ModalFooter>
             <ChakraPagination
               pt="4"
-              limit={environment.PAGINATION_LIMIT}
-              limits={[environment.PAGINATION_LIMIT]} //, 24, 36, 48]}
+              limit={OwnerPaginationLimit}
               page={page}
               total={
                 data?.ownerships?.totalCount ||
                 previousData?.ownerships?.totalCount
               }
               onPageChange={setPage}
-              simple
-              onLimitChange={(limit) => setLimit(parseInt(limit, 10))}
+              hideSelectors
               result={{
                 label: t('pagination.result.label'),
                 caption: (props) => (

--- a/components/Token/Owners/ModalActivator.tsx
+++ b/components/Token/Owners/ModalActivator.tsx
@@ -8,10 +8,14 @@ export type Props = ButtonHTMLAttributes<any> & {
     image: string | null | undefined
     name: string | null | undefined
   }[]
-  ownerCount: number
+  numberOfOwners: number
 }
 
-const OwnersModalActivator: VFC<Props> = ({ owners, ownerCount, ...props }) => {
+const OwnersModalActivator: VFC<Props> = ({
+  owners,
+  numberOfOwners,
+  ...props
+}) => {
   return (
     <Flex as="button" {...props}>
       {owners.slice(0, 4).map(({ address, image, name }, index) => (
@@ -32,7 +36,7 @@ const OwnersModalActivator: VFC<Props> = ({ owners, ownerCount, ...props }) => {
           />
         </Flex>
       ))}
-      {ownerCount === 5 && owners[4] && (
+      {numberOfOwners === 5 && owners[4] && (
         <Flex ml={-3} title={owners[4].name ? owners[4].name : ''}>
           <Box
             as={AccountImage}
@@ -44,7 +48,7 @@ const OwnersModalActivator: VFC<Props> = ({ owners, ownerCount, ...props }) => {
           />
         </Flex>
       )}
-      {ownerCount > 5 && (
+      {numberOfOwners > 5 && (
         <Flex ml={-3} zIndex={10}>
           <Flex
             h={8}
@@ -55,7 +59,7 @@ const OwnersModalActivator: VFC<Props> = ({ owners, ownerCount, ...props }) => {
             bgColor="brand.50"
           >
             <Text as="span" variant="caption" color="brand.500">
-              {`+${ownerCount >= 103 ? 99 : owners.length - 4}`}
+              {`+${numberOfOwners >= 103 ? 99 : owners.length - 4}`}
             </Text>
           </Flex>
         </Flex>

--- a/components/Token/Owners/ModalActivator.tsx
+++ b/components/Token/Owners/ModalActivator.tsx
@@ -8,9 +8,10 @@ export type Props = ButtonHTMLAttributes<any> & {
     image: string | null | undefined
     name: string | null | undefined
   }[]
+  ownerCount: number
 }
 
-const OwnersModalActivator: VFC<Props> = ({ owners, ...props }) => {
+const OwnersModalActivator: VFC<Props> = ({ owners, ownerCount, ...props }) => {
   return (
     <Flex as="button" {...props}>
       {owners.slice(0, 4).map(({ address, image, name }, index) => (
@@ -31,7 +32,7 @@ const OwnersModalActivator: VFC<Props> = ({ owners, ...props }) => {
           />
         </Flex>
       ))}
-      {owners.length === 5 && owners[4] && (
+      {ownerCount === 5 && owners[4] && (
         <Flex ml={-3} title={owners[4].name ? owners[4].name : ''}>
           <Box
             as={AccountImage}
@@ -43,7 +44,7 @@ const OwnersModalActivator: VFC<Props> = ({ owners, ...props }) => {
           />
         </Flex>
       )}
-      {owners.length > 5 && (
+      {ownerCount > 5 && (
         <Flex ml={-3} zIndex={10}>
           <Flex
             h={8}
@@ -54,7 +55,7 @@ const OwnersModalActivator: VFC<Props> = ({ owners, ...props }) => {
             bgColor="brand.50"
           >
             <Text as="span" variant="caption" color="brand.500">
-              {`+${owners.length >= 103 ? 99 : owners.length - 4}`}
+              {`+${ownerCount >= 103 ? 99 : owners.length - 4}`}
             </Text>
           </Flex>
         </Flex>

--- a/hooks/useFetchOwners.gql
+++ b/hooks/useFetchOwners.gql
@@ -1,0 +1,26 @@
+query FetchOwners($assetId: String!, $offset: Int!, $limit: Int!) {
+  ownerships(
+    filter: { assetId: { equalTo: $assetId } }
+    offset: $offset
+    first: $limit
+    orderBy: [
+      QUANTITY_DESC
+      ACCOUNT_BY_OWNER_ADDRESS__NAME_ASC
+      OWNER_ADDRESS_ASC
+    ]
+  ) {
+    totalCount
+    nodes {
+      quantity
+      ownerAddress
+      owner {
+        address
+        name
+        image
+        verification {
+          status
+        }
+      }
+    }
+  }
+}

--- a/pages/collection/[chainId]/[id].gql
+++ b/pages/collection/[chainId]/[id].gql
@@ -92,19 +92,6 @@ query FetchCollectionAssets(
           }
         }
       }
-      ownerships {
-        aggregates {
-          sum {
-            quantity
-          }
-        }
-        nodes {
-          owner {
-            address
-            name
-          }
-        }
-      }
       bestBid: bids(
         orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
         filter: { expiredAt: { greaterThan: $now } }

--- a/pages/index.gql
+++ b/pages/index.gql
@@ -46,6 +46,7 @@ fragment HomeAssetDetail on Asset {
       ACCOUNT_BY_OWNER_ADDRESS__NAME_ASC
       OWNER_ADDRESS_ASC
     ]
+    first: 5
   ) {
     nodes {
       ownerAddress

--- a/pages/index.gql
+++ b/pages/index.gql
@@ -48,6 +48,7 @@ fragment HomeAssetDetail on Asset {
     ]
     first: 5
   ) {
+    totalCount
     nodes {
       ownerAddress
       quantity

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -163,6 +163,10 @@ const HomePage: NextPage<Props> = ({
           sales={asset.sales.nodes.map(convertSaleFull)}
           creator={convertUser(asset.creator, asset.creator.address)}
           owners={asset.ownerships.nodes.map(convertOwnership)}
+          ownerCount={parseInt(
+            asset.ownerships.aggregates?.sum?.quantity || '0',
+            10,
+          )}
           isHomepage={true}
           signer={signer}
           currentAccount={account?.toLowerCase()}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -163,10 +163,7 @@ const HomePage: NextPage<Props> = ({
           sales={asset.sales.nodes.map(convertSaleFull)}
           creator={convertUser(asset.creator, asset.creator.address)}
           owners={asset.ownerships.nodes.map(convertOwnership)}
-          ownerCount={parseInt(
-            asset.ownerships.aggregates?.sum?.quantity || '0',
-            10,
-          )}
+          numberOfOwners={asset.ownerships.totalCount}
           isHomepage={true}
           signer={signer}
           currentAccount={account?.toLowerCase()}

--- a/pages/tokens/[id]/index.gql
+++ b/pages/tokens/[id]/index.gql
@@ -82,6 +82,7 @@ query FetchAsset($id: String!, $address: Address, $now: Datetime!) {
       ]
       first: 5
     ) {
+      totalCount
       nodes {
         ownerAddress
         quantity

--- a/pages/tokens/[id]/index.gql
+++ b/pages/tokens/[id]/index.gql
@@ -80,6 +80,7 @@ query FetchAsset($id: String!, $address: Address, $now: Datetime!) {
         ACCOUNT_BY_OWNER_ADDRESS__NAME_ASC
         OWNER_ADDRESS_ASC
       ]
+      first: 5
     ) {
       nodes {
         ownerAddress

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -432,6 +432,10 @@ const DetailPage: NextPage<Props> = ({
           <TokenMetadata
             creator={creator}
             owners={owners}
+            ownerCount={parseInt(
+              asset.ownerships.aggregates?.sum?.quantity || '0',
+              10,
+            )}
             saleSupply={BigNumber.from(
               asset.sales.aggregates?.sum?.availableQuantity || 0,
             )}

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -430,6 +430,7 @@ const DetailPage: NextPage<Props> = ({
           </Flex>
 
           <TokenMetadata
+            assetId={asset.id}
             creator={creator}
             owners={owners}
             ownerCount={parseInt(

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -433,10 +433,7 @@ const DetailPage: NextPage<Props> = ({
             assetId={asset.id}
             creator={creator}
             owners={owners}
-            ownerCount={parseInt(
-              asset.ownerships.aggregates?.sum?.quantity || '0',
-              10,
-            )}
+            numberOfOwners={asset.ownerships.totalCount}
             saleSupply={BigNumber.from(
               asset.sales.aggregates?.sum?.availableQuantity || 0,
             )}


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/starter-kit/issues/92

### Description

Limit the size of queries by only fetching required owners and not all the owners for a specific asset.
All owners are loaded when needed and paginated when opening the dedicated modal about ownership
