### PR TITLE
Fix allow top up config in navbar

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -130,7 +130,7 @@ function Layout({
       <Box mt={12}>
         <Banner />
         <Navbar
-          allowTopUp={true}
+          allowTopUp={environment.ALLOW_TOP_UP}
           router={{
             asPath: router.asPath,
             isReady: router.isReady,


### PR DESCRIPTION
### Project organization

- Closes <!-- add link to issue that this PR fixes if any -->
- Related <!-- add link to related issue if any -->
- Dependant on <!-- add link to dependant PR if any -->

### Description

Fix the allow top up config in navbar, it was not reading the config from environment.

### How to test

<!-- A concise explanation how to test this PR with links -->

### Checklist

- [x] Base branch of the PR is `dev`
- [ ] Update docs if necessary <!-- Docs in https://github.com/liteflow-labs/liteflow-js/tree/main/docs/pages/starter-kit -->
