### PR TITLE
simplify refresh asset query

### DIFF
--- a/hooks/useRefreshAsset.gql
+++ b/hooks/useRefreshAsset.gql
@@ -1,10 +1,6 @@
 query GetAssetDataForRefresh($assetId: String!) {
   asset(id: $assetId) {
     updatedAt
-    # fetch transfer from histories to know if the asset is minted
-    histories(condition: { action: TRANSFER }) {
-      totalCount
-    }
   }
 }
 

--- a/hooks/useRefreshAsset.ts
+++ b/hooks/useRefreshAsset.ts
@@ -50,12 +50,7 @@ export default function useRefreshAsset(
   const refreshAsset = useCallback(
     async (assetId: string) => {
       // fetch the last updated date of this asset
-      const { updatedAt: initialUpdatedAt, histories } = await getAssetData(
-        assetId,
-      )
-
-      // check if asset is minted, if not minted, cannot refresh asset
-      if (histories.totalCount === 0) return
+      const { updatedAt: initialUpdatedAt } = await getAssetData(assetId)
 
       // ask backend to refresh asset
       await refreshAssetMutation({


### PR DESCRIPTION
### Description

Simplify the refresh asset query now that the backend is compatible with refresh of lazy mint asset.

### How to test

- Test the refresh on a minted token: https://nft-test-polygon-mumbai-git-fix-simplify-refresh-asset-liteflow.vercel.app/tokens/80001-0xe3fe92dfec700e7a168f4b074ee7daca71a11397-42728329798185476104569684045014434977602555793693135036363296381964103551044
- Test the refresh on a lazy minted token, not yet minted: https://nft-test-polygon-mumbai-git-fix-simplify-refresh-asset-liteflow.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139411010012577917159637602

### Checklist

- [x] Base branch of the PR is `dev`
- [ ] Update docs if necessary <!-- Docs in https://github.com/liteflow-labs/liteflow-js/tree/main/docs/pages/starter-kit -->
