### PR TITLE
Fix summary when fees are zero

### DIFF
--- a/components/Offer/Summary.tsx
+++ b/components/Offer/Summary.tsx
@@ -51,7 +51,7 @@ const Summary: FC<
           </Heading>
         </>
       )}
-      {feesOnTopPerTenThousand && (
+      {feesOnTopPerTenThousand !== undefined && (
         <Heading as={Flex} variant="heading3" color="gray.500" mb={2}>
           {t('offer.summary.fees', { value: feesOnTopPerTenThousand / 100 })}
           <Text


### PR DESCRIPTION
### Description

Fix summary when fees are zero:

![image](https://user-images.githubusercontent.com/5823445/215750782-0f96aa46-0037-410e-a572-dbd6d35c9f3a.png)

I guess we have other similar issues in the codebase. Any idea how to find them efficently?

### Checklist

- [x] Base branch of the PR is `dev`
- [ ] Update docs if necessary <!-- Docs in https://github.com/liteflow-labs/liteflow-js/tree/main/docs/pages/starter-kit -->
