### PR TITLE
Type connectors

### DIFF
--- a/connectors.ts
+++ b/connectors.ts
@@ -4,7 +4,12 @@ import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
 import { WalletLinkConnector } from '@web3-react/walletlink-connector'
 import environment from './environment'
 
-const connectors = {
+const connectors: {
+  email?: EmailConnector
+  injected?: InjectedConnector
+  walletConnect?: WalletConnectConnector
+  coinbase?: WalletLinkConnector
+} = {
   email: new EmailConnector({
     apiKey: environment.MAGIC_API_KEY,
     options: {


### PR DESCRIPTION
### Description

Type connectors payload in `connectors.ts`.

I was customising this file and needed to remove the EmailConnector. I tried to remove the `email` but it breaks the build because some other file requires `connectors.email`, even if it's undefined.
By simply putting the type with optional, the following payload doesn't break the build anymore:
```ts
const connectors: {
  email?: EmailConnector
  injected?: InjectedConnector
  walletConnect?: WalletConnectConnector
  coinbase?: WalletLinkConnector
} = {
  injected: new InjectedConnector({
    supportedChainIds: [environment.CHAIN_ID],
  }),
  walletConnect: new WalletConnectConnector({
    rpc: {
      [environment.CHAIN_ID]: environment.PUBLIC_ETHEREUM_PROVIDER,
    },
    supportedChainIds: [environment.CHAIN_ID],
    chainId: environment.CHAIN_ID,
  }),
  coinbase: new WalletLinkConnector({
```

### Checklist

- [x] Base branch of the PR is `dev`
