### PR TITLE
Fix aspect ratio of token media

### DIFF
--- a/components/Token/Card.tsx
+++ b/components/Token/Card.tsx
@@ -1,4 +1,5 @@
 import {
+  AspectRatio,
   Box,
   Flex,
   Heading,
@@ -152,14 +153,15 @@ const TokenCard: VFC<Props> = ({
       onMouseLeave={() => setIsHovered(false)}
     >
       <Flex as={Link} href={href} w="full" position="relative">
-        <TokenMedia
-          image={asset.image}
-          animationUrl={asset.animationUrl}
-          unlockedContent={asset.unlockedContent}
-          defaultText={asset.name}
-          objectFit="cover"
-          layout="fill"
-        />
+        <AspectRatio w="full" ratio={1}>
+          <TokenMedia
+            image={asset.image}
+            animationUrl={asset.animationUrl}
+            unlockedContent={asset.unlockedContent}
+            defaultText={asset.name}
+            fill={true}
+          />
+        </AspectRatio>
         {auction && (
           <HStack
             position="absolute"

--- a/components/Token/Header.tsx
+++ b/components/Token/Header.tsx
@@ -1,4 +1,11 @@
-import { Box, Flex, Heading, SimpleGrid, Stack } from '@chakra-ui/react'
+import {
+  AspectRatio,
+  Box,
+  Flex,
+  Heading,
+  SimpleGrid,
+  Stack,
+} from '@chakra-ui/react'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
 import { useMemo, VFC } from 'react'
@@ -77,8 +84,9 @@ const TokenHeader: VFC<Props> = ({
           as={Link}
           href={`/tokens/${asset.id}`}
           mx="auto"
-          maxH={96}
+          maxH="sm"
           w="full"
+          h="full"
           maxW="sm"
           align="center"
           justify="center"
@@ -86,14 +94,15 @@ const TokenHeader: VFC<Props> = ({
           rounded="lg"
           shadow="md"
         >
-          <TokenMedia
-            image={asset.image}
-            animationUrl={asset.animationUrl}
-            unlockedContent={asset.unlockedContent}
-            defaultText={asset.name}
-            objectFit="cover"
-            layout="fill"
-          />
+          <AspectRatio w="full" ratio={1}>
+            <TokenMedia
+              image={asset.image}
+              animationUrl={asset.animationUrl}
+              unlockedContent={asset.unlockedContent}
+              defaultText={asset.name}
+              fill={true}
+            />
+          </AspectRatio>
         </Flex>
       </Box>
       <Stack spacing={8} p={{ base: 6, md: 12 }}>

--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -4,19 +4,18 @@ import { useEffect, useState, VFC } from 'react'
 import Image from '../Image/Image'
 
 const TokenMedia: VFC<{
-    image: string | null | undefined
-    animationUrl: string | null | undefined
-    unlockedContent: { url: string; mimetype: string | null } | null | undefined
-    defaultText?: string
-    controls?: boolean | undefined
-    layout?: string | undefined
-  }
-> = ({
+  image: string | null | undefined
+  animationUrl: string | null | undefined
+  unlockedContent: { url: string; mimetype: string | null } | null | undefined
+  defaultText?: string
+  controls?: boolean
+  fill?: boolean
+}> = ({
   image,
   animationUrl,
   unlockedContent,
   defaultText,
-  layout,
+  fill,
   controls,
 }) => {
   const { colors } = useTheme()
@@ -35,13 +34,16 @@ const TokenMedia: VFC<{
 
   if (animationUrl) {
     return (
-      <video
+      <Box
+        as="video"
         src={animationUrl}
         autoPlay
         playsInline
         muted
         loop
         controls={controls}
+        w={fill ? 'auto' : 'full'}
+        h={fill ? 'auto' : 'full'}
       />
     )
   }
@@ -69,7 +71,8 @@ const TokenMedia: VFC<{
           src={image}
           alt={defaultText}
           onError={() => setImageError(true)}
-          layout={layout}
+          layout="fill"
+          objectFit={fill ? 'cover' : 'scale-down'}
         />
       </Box>
     )

--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -66,7 +66,7 @@ const TokenMedia: VFC<{
       )
 
     return (
-      <Box position="relative" w="full" pt="100%">
+      <Box position="relative" w="full" h="full">
         <Image
           src={image}
           alt={defaultText}

--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -1,10 +1,9 @@
 import { Box, Center, Icon, Stack, Text, useTheme } from '@chakra-ui/react'
 import { FaImage } from '@react-icons/all-files/fa/FaImage'
-import Image, { ImageProps } from 'next/image'
-import { useEffect, useState, VFC, VideoHTMLAttributes } from 'react'
+import { useEffect, useState, VFC } from 'react'
+import Image from '../Image/Image'
 
-const TokenMedia: VFC<
-  (Omit<VideoHTMLAttributes<any>, 'src'> | Omit<ImageProps, 'src'>) & {
+const TokenMedia: VFC<{
     image: string | null | undefined
     animationUrl: string | null | undefined
     unlockedContent: { url: string; mimetype: string | null } | null | undefined
@@ -19,7 +18,6 @@ const TokenMedia: VFC<
   defaultText,
   layout,
   controls,
-  ...props
 }) => {
   const { colors } = useTheme()
   // prioritize unlockedContent
@@ -36,7 +34,6 @@ const TokenMedia: VFC<
   }, [image])
 
   if (animationUrl) {
-    const { objectFit, src, ...videoProps } = props as ImageProps
     return (
       <video
         src={animationUrl}
@@ -45,12 +42,10 @@ const TokenMedia: VFC<
         muted
         loop
         controls={controls}
-        {...(videoProps as Omit<VideoHTMLAttributes<any>, 'src'>)}
       />
     )
   }
   if (image) {
-    const rest = props as Omit<ImageProps, 'src'>
     if (imageError)
       return (
         <>
@@ -68,15 +63,13 @@ const TokenMedia: VFC<
         </>
       )
 
-    const customTag = { Image: Image as any }
     return (
       <Box position="relative" w="full" pt="100%">
-        <customTag.Image
+        <Image
           src={image}
           alt={defaultText}
           onError={() => setImageError(true)}
           layout={layout}
-          {...rest}
         />
       </Box>
     )

--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -42,8 +42,8 @@ const TokenMedia: VFC<{
         muted
         loop
         controls={controls}
-        w={fill ? 'auto' : 'full'}
-        h={fill ? 'auto' : 'full'}
+        maxW="full"
+        maxH="full"
       />
     )
   }

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -311,20 +311,13 @@ const DetailPage: NextPage<Props> = ({
             p={12}
             bg="brand.50"
           >
-            <Box position="relative" w="full" zIndex={1}>
-              <Box
-                as={TokenMedia}
-                image={asset.image}
-                animationUrl={asset.animationUrl}
-                unlockedContent={
-                  showPreview ? undefined : asset.unlockedContent
-                }
-                defaultText={asset.name}
-                objectFit="cover"
-                layout="fill"
-                controls
-              />
-            </Box>
+            <TokenMedia
+              image={asset.image}
+              animationUrl={asset.animationUrl}
+              unlockedContent={showPreview ? undefined : asset.unlockedContent}
+              defaultText={asset.name}
+              controls
+            />
             {asset.hasUnlockableContent && (
               <Flex
                 w="full"


### PR DESCRIPTION
### Description

#### Fix the aspect ratio of token media when displayed as a square (token card and token header)

Before the UI updates (main branch) of the token card and token page, the media was properly displayed as a square, but the videos (first 2 nfts) didn't filled the space, resulting in white borders:

<img width="1262" alt="Screenshot 2023-02-04 at 19 07 39" src="https://user-images.githubusercontent.com/5823445/216766790-fe4acc0c-d4f7-4f4e-ba2d-afecbbdf4780.png">

Source: https://liteflow-nft-test-polygon-mumbai.vercel.app

After the UI updates (dev branch), the media are not limited in height at all:
<img width="1262" alt="Screenshot 2023-02-04 at 19 09 41" src="https://user-images.githubusercontent.com/5823445/216766889-4bbf65e6-ef50-4f95-9f30-f26a422466a0.png">

Source: https://liteflow-nft-test-dev-polygon-mumbai.vercel.app/

Now wit this PR, the video are properly squared to fill the place:
<img width="1262" alt="Screenshot 2023-02-04 at 19 11 27" src="https://user-images.githubusercontent.com/5823445/216766972-a1b76938-dd06-448c-aef7-91e450d4c030.png">

Source: https://nft-test-polygon-mumbai-git-fix-token-media-asp-20969e-liteflow.vercel.app/

#### Fix the media ratio on the token page

Then, the UI updates bring some regression on the token page.
Before (main branch):
<img width="1262" alt="Screenshot 2023-02-04 at 19 14 57" src="https://user-images.githubusercontent.com/5823445/216767126-a6ae3e81-f6ff-4db5-a1f6-87112f4aee97.png">
Source: https://liteflow-nft-test-polygon-mumbai.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688045754842099928417655
or https://liteflow-nft-test-polygon-mumbai.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688022518523903183557889
or https://liteflow-nft-test-polygon-mumbai.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688029603075124255299633

After UI updates (dev branch):
<img width="1262" alt="Screenshot 2023-02-04 at 19 14 00" src="https://user-images.githubusercontent.com/5823445/216767082-5d6d2a21-610a-4f9d-8d09-906d7386b18b.png">

Source: https://liteflow-nft-test-dev-polygon-mumbai.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688045754842099928417655
or https://liteflow-nft-test-dev-polygon-mumbai.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688022518523903183557889
or https://liteflow-nft-test-dev-polygon-mumbai.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688029603075124255299633

With this PR: 
<img width="1262" alt="Screenshot 2023-02-04 at 19 15 31" src="https://user-images.githubusercontent.com/5823445/216767150-8b752bd2-8ee4-47f8-9d96-d2bcf116441e.png">

Source: https://nft-test-polygon-mumbai-git-fix-token-media-asp-20969e-liteflow.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688045754842099928417655
or https://nft-test-polygon-mumbai-git-fix-token-media-asp-20969e-liteflow.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688022518523903183557889
or https://nft-test-polygon-mumbai-git-fix-token-media-asp-20969e-liteflow.vercel.app/tokens/80001-0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3-42728329798185476104569684045014434977602555793693139688029603075124255299633

### How to test

Compared the different versions:
- Main branch: https://liteflow-nft-test-polygon-mumbai.vercel.app
- Dev branch: https://liteflow-nft-test-dev-polygon-mumbai.vercel.app
- This PR: https://nft-test-polygon-mumbai-git-fix-token-media-asp-20969e-liteflow.vercel.app

### Checklist

- [x] Base branch of the PR is `dev`
