### PR TITLE
Fix unlockable GIF

### DIFF
--- a/components/Image/Image.tsx
+++ b/components/Image/Image.tsx
@@ -12,7 +12,8 @@ const Image = chakra(NextImage, {
       'quality',
       'placeholder',
       'blurDataURL',
-      'loader ',
+      'loader',
+      'unoptimized',
     ].includes(prop),
 })
 

--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -19,6 +19,7 @@ const TokenMedia: VFC<{
   controls,
 }) => {
   const { colors } = useTheme()
+
   // prioritize unlockedContent
   if (unlockedContent) {
     if (unlockedContent.mimetype?.startsWith('video/'))
@@ -73,6 +74,7 @@ const TokenMedia: VFC<{
           onError={() => setImageError(true)}
           layout="fill"
           objectFit={fill ? 'cover' : 'scale-down'}
+          unoptimized={unlockedContent?.mimetype === 'image/gif'}
         />
       </Box>
     )


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/starter-kit/issues/162

### Description

Fix display of unlockable GIF by bypassing the next/image optimisation rendering.

@EmmanuelDrouin I ask your review to double-check this PR fix the display of the gif with your assets.

### How to test

- Create an asset with any gif as unlockable content
- Check the gif is loaded properly
- Check the gif is not loaded properly with the dev branch

### Checklist

- [x] Base branch of the PR is `dev`
