### PR TITLE
Switch from Avatar to AccountImage in UserCard

### DIFF
--- a/components/User/UserCard.tsx
+++ b/components/User/UserCard.tsx
@@ -1,9 +1,10 @@
-import { Avatar, Box, Flex, Icon, Text } from '@chakra-ui/react'
+import { Box, Flex, Icon, Text } from '@chakra-ui/react'
 import { formatAddress } from '@nft/hooks'
 import { HiBadgeCheck } from '@react-icons/all-files/hi/HiBadgeCheck'
 import Image from 'components/Image/Image'
 import Link from 'components/Link/Link'
 import { FC } from 'react'
+import AccountImage from '../Wallet/Image'
 
 type Props = {
   user: {
@@ -40,15 +41,18 @@ const UserCard: FC<Props> = ({ user }) => {
             position="absolute"
             bottom={0}
             transform="translate(1rem, 50%)"
-            bg="black"
             border="2px solid"
             borderColor="white"
             rounded="full"
+            w={16}
+            h={16}
           >
-            <Avatar
-              size="lg"
-              src={user.image || undefined}
-              title={user.name || user.address}
+            <Box
+              as={AccountImage}
+              address={user.address}
+              image={user.image}
+              size={60}
+              rounded="full"
             />
           </Box>
         </Box>

--- a/components/User/UserCard.tsx
+++ b/components/User/UserCard.tsx
@@ -52,6 +52,7 @@ const UserCard: FC<Props> = ({ user }) => {
               address={user.address}
               image={user.image}
               size={60}
+              objectFit="cover"
               rounded="full"
             />
           </Box>


### PR DESCRIPTION
### Description

Switch from `Avatar` to `AccountImage` in `UserCard` component to be able to use the optimised users' image.

The `Avatar` component from Chakra UI, that implement a nice fallback if the user's image is not set, doesn't optimise the image loaded.
I replaced it by the `AccountImage` that do the optimisation + default to the "Metamask" icon.

@EmmanuelDrouin I would like you to confirm the UI modifications. There are two big UI changes:
- The default / placeholder image is the "metamask" icon.
- The size of the image is a bit smaller because of chakra's size limitation (the next possible size is a loot bigger)

Before:
<img width="1244" alt="Screenshot 2023-02-07 at 23 04 24" src="https://user-images.githubusercontent.com/5823445/217297860-6f914cc3-06e1-4229-be2e-50d2340ced32.png">

After:
<img width="1244" alt="Screenshot 2023-02-07 at 23 04 31" src="https://user-images.githubusercontent.com/5823445/217297906-1b2b96ec-15d1-4ba8-8b90-a6d62b8f4487.png">


### How to test

- Navigate to the explore/users page

### Checklist

- [x] Base branch of the PR is `dev`
