### PR TITLE
Fix issue with shallow navigation

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -445,6 +445,7 @@ const Navbar: VFC<{
     if (data.search) query.search = data.search
     else delete query.search
     delete query.skip // reset pagination
+    delete query.page // reset pagination
     if (router.asPath.startsWith('/explore')) return push({ query })
     return push({ pathname: '/explore', query })
   })

--- a/hooks/useOrderByQuery.ts
+++ b/hooks/useOrderByQuery.ts
@@ -1,0 +1,10 @@
+import invariant from 'ts-invariant'
+import useQueryParamSingle from './useQueryParamSingle'
+
+export default function useOrderByQuery<T>(defaultValue: T): T {
+  const orderBy = useQueryParamSingle<T>('orderBy', {
+    defaultValue: defaultValue,
+  })
+  invariant(orderBy, 'orderBy is falsy')
+  return orderBy
+}

--- a/hooks/usePaginateQuery.ts
+++ b/hooks/usePaginateQuery.ts
@@ -1,0 +1,32 @@
+import invariant from 'ts-invariant'
+import environment from '../environment'
+import useQueryParamSingle from './useQueryParamSingle'
+
+type PaginateQuery = {
+  page: number
+  limit: number
+  offset: number
+}
+
+export default function usePaginateQuery({
+  defaultLimit = environment.PAGINATION_LIMIT,
+}: {
+  defaultLimit?: number
+} = {}): PaginateQuery {
+  const page = useQueryParamSingle('page', {
+    defaultValue: 1,
+    parse: (value) => (value ? parseInt(value, 10) : 1),
+  })
+  invariant(page, 'page is falsy')
+  const limit = useQueryParamSingle('limit', {
+    defaultValue: defaultLimit,
+    parse: (value) => (value ? parseInt(value, 10) : defaultLimit),
+  })
+  invariant(limit, 'limit is falsy')
+  const offset = (page - 1) * limit
+  return {
+    page,
+    limit,
+    offset,
+  }
+}

--- a/pages/collection/[chainId]/[id].tsx
+++ b/pages/collection/[chainId]/[id].tsx
@@ -60,7 +60,9 @@ import useAssetFilterFromQuery, {
 import useEagerConnect from '../../../hooks/useEagerConnect'
 import useExecuteOnAccountChange from '../../../hooks/useExecuteOnAccountChange'
 import useFilterState from '../../../hooks/useFilterState'
+import useOrderByQuery from '../../../hooks/useOrderByQuery'
 import usePaginate from '../../../hooks/usePaginate'
+import usePaginateQuery from '../../../hooks/usePaginateQuery'
 import LargeLayout from '../../../layouts/large'
 
 type Props = {
@@ -68,12 +70,6 @@ type Props = {
   collectionAddress: string
   currentAccount: string | null
   now: string
-  // Pagination
-  limit: number
-  page: number
-  offset: number
-  // OrderBy
-  orderBy: AssetsOrderBy
   // Currencies
   currencies: Pick<Currency, 'id' | 'image' | 'decimals'>[]
 }
@@ -193,10 +189,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
         collectionAddress: collectionAddress,
         currentAccount: ctx.user.address,
         now: now.toJSON(),
-        limit,
-        page,
-        offset,
-        orderBy,
         currencies: currencies?.nodes || [],
       },
     }
@@ -208,10 +200,6 @@ const CollectionPage: FC<Props> = ({
   collectionAddress,
   now,
   currentAccount,
-  limit,
-  page,
-  offset,
-  orderBy,
   currencies,
 }) => {
   const ready = useEagerConnect()
@@ -226,6 +214,10 @@ const CollectionPage: FC<Props> = ({
       chainId: chainId,
     },
   })
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<AssetsOrderBy>(
+    'SALES_MIN_UNIT_PRICE_IN_REF_ASC',
+  )
   const filter = useAssetFilterFromQuery(currencies)
   const { data, refetch } = useFetchCollectionAssetsQuery({
     variables: {
@@ -251,7 +243,7 @@ const CollectionPage: FC<Props> = ({
           return { ...acc, [value]: query[value] }
         }, {}),
         ...otherFilters,
-        page: undefined,
+        page: 1,
         ...traits.reduce(
           (acc, { type, values }) => ({
             ...acc,

--- a/pages/explore/collections.tsx
+++ b/pages/explore/collections.tsx
@@ -20,17 +20,14 @@ import {
   useFetchExploreCollectionsQuery,
 } from '../../graphql'
 import useEagerConnect from '../../hooks/useEagerConnect'
+import useOrderByQuery from '../../hooks/useOrderByQuery'
 import usePaginate from '../../hooks/usePaginate'
+import usePaginateQuery from '../../hooks/usePaginateQuery'
+import useQueryParamSingle from '../../hooks/useQueryParamSingle'
 import { wrapServerSideProps } from '../../props'
 
-type Props = {
-  limit: number
-  page: number
-  offset: number
-  orderBy: CollectionsOrderBy
-  queryFilter: CollectionFilter[]
-  search: string | null
-}
+type Props = {}
+
 const searchFilter = (search: string): CollectionFilter =>
   ({
     or: [
@@ -67,42 +64,31 @@ export const getServerSideProps = wrapServerSideProps<Props>(
 
     const { data, error } = await client.query<FetchExploreCollectionsQuery>({
       query: FetchExploreCollectionsDocument,
-      variables: { limit, offset, filter: queryFilter },
+      variables: { limit, offset, filter: queryFilter, orderBy },
     })
     if (error) throw error
     if (!data) throw new Error('data is falsy')
 
     return {
-      props: {
-        limit,
-        page,
-        offset,
-        orderBy,
-        queryFilter,
-        search,
-      },
+      props: {},
     }
   },
 )
 
-const CollectionsPage: NextPage<Props> = ({
-  offset,
-  limit,
-  orderBy,
-  page,
-  queryFilter,
-  search,
-}) => {
+const CollectionsPage: NextPage<Props> = ({}) => {
   useEagerConnect()
   const { pathname, query, replace } = useRouter()
   const { t } = useTranslation('templates')
   const [loadingOrder, setLoadingOrder] = useState(false)
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<CollectionsOrderBy>('TOTAL_VOLUME_DESC')
+  const search = useQueryParamSingle('search')
   const { data } = useFetchExploreCollectionsQuery({
     variables: {
       limit,
       offset,
       orderBy,
-      filter: queryFilter,
+      filter: search ? searchFilter(search) : [],
     },
   })
 

--- a/pages/explore/users.tsx
+++ b/pages/explore/users.tsx
@@ -1,11 +1,11 @@
 import { chakra, Flex, SimpleGrid, Text } from '@chakra-ui/react'
-import ExploreTemplate from 'components/Explore'
-import Head from 'components/Head'
 import { NextPage } from 'next'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { useMemo } from 'react'
 import Empty from '../../components/Empty/Empty'
+import ExploreTemplate from '../../components/Explore'
+import Head from '../../components/Head'
 import Pagination from '../../components/Pagination/Pagination'
 import UserCard from '../../components/User/UserCard'
 import { convertUserWithCover } from '../../convert'
@@ -18,15 +18,12 @@ import {
 } from '../../graphql'
 import useEagerConnect from '../../hooks/useEagerConnect'
 import usePaginate from '../../hooks/usePaginate'
+import usePaginateQuery from '../../hooks/usePaginateQuery'
+import useQueryParamSingle from '../../hooks/useQueryParamSingle'
 import { wrapServerSideProps } from '../../props'
 
-type Props = {
-  limit: number
-  page: number
-  offset: number
-  queryFilter: AccountFilter[]
-  search: string | null
-}
+type Props = {}
+
 const searchFilter = (search: string): AccountFilter =>
   ({
     or: [
@@ -66,31 +63,21 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     if (!data) throw new Error('data is falsy')
 
     return {
-      props: {
-        limit,
-        page,
-        offset,
-        queryFilter,
-        search,
-      },
+      props: {},
     }
   },
 )
 
-const UsersPage: NextPage<Props> = ({
-  offset,
-  limit,
-  page,
-  queryFilter,
-  search,
-}) => {
+const UsersPage: NextPage<Props> = () => {
   useEagerConnect()
   const { t } = useTranslation('templates')
+  const { limit, offset, page } = usePaginateQuery()
+  const search = useQueryParamSingle('search')
   const { data } = useFetchExploreUsersQuery({
     variables: {
       limit,
       offset,
-      filter: queryFilter,
+      filter: search ? searchFilter(search) : [],
     },
   })
 

--- a/pages/users/[id]/bids/placed.tsx
+++ b/pages/users/[id]/bids/placed.tsx
@@ -47,19 +47,17 @@ import {
 } from '../../../../graphql'
 import useBlockExplorer from '../../../../hooks/useBlockExplorer'
 import useEagerConnect from '../../../../hooks/useEagerConnect'
+import useOrderByQuery from '../../../../hooks/useOrderByQuery'
 import usePaginate from '../../../../hooks/usePaginate'
+import usePaginateQuery from '../../../../hooks/usePaginateQuery'
 import useSigner from '../../../../hooks/useSigner'
 import LargeLayout from '../../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../../params'
+import { getLimit, getOffset, getOrder } from '../../../../params'
 import { wrapServerSideProps } from '../../../../props'
 
 type Props = {
   userAddress: string
   now: string
-  page: number
-  limit: number
-  offset: number
-  orderBy: OfferOpenBuysOrderBy
   meta: {
     title: string
     description: string
@@ -77,7 +75,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
       : null
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, environment.PAGINATION_LIMIT)
-    const page = getPage(context)
     const orderBy = getOrder<OfferOpenBuysOrderBy>(context, 'CREATED_AT_DESC')
     const offset = getOffset(context, environment.PAGINATION_LIMIT)
     const now = new Date()
@@ -95,10 +92,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     if (!data) throw new Error('data is falsy')
     return {
       props: {
-        page,
-        limit,
-        offset,
-        orderBy,
         userAddress,
         now: now.toJSON(),
         meta: {
@@ -111,20 +104,14 @@ export const getServerSideProps = wrapServerSideProps<Props>(
   },
 )
 
-const BidPlacedPage: NextPage<Props> = ({
-  meta,
-  now,
-  limit,
-  page,
-  offset,
-  orderBy,
-  userAddress,
-}) => {
+const BidPlacedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
   useEagerConnect()
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { replace, pathname, query } = useRouter()
   const { account } = useWeb3React()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<OfferOpenBuysOrderBy>('CREATED_AT_DESC')
   const [changePage, changeLimit] = usePaginate()
   const [cancel, { activeStep, transactionHash }] = useCancelOffer(signer)
   const toast = useToast()

--- a/pages/users/[id]/bids/received.tsx
+++ b/pages/users/[id]/bids/received.tsx
@@ -48,19 +48,17 @@ import {
 } from '../../../../graphql'
 import useBlockExplorer from '../../../../hooks/useBlockExplorer'
 import useEagerConnect from '../../../../hooks/useEagerConnect'
+import useOrderByQuery from '../../../../hooks/useOrderByQuery'
 import usePaginate from '../../../../hooks/usePaginate'
+import usePaginateQuery from '../../../../hooks/usePaginateQuery'
 import useSigner from '../../../../hooks/useSigner'
 import LargeLayout from '../../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../../params'
+import { getLimit, getOffset, getOrder } from '../../../../params'
 import { wrapServerSideProps } from '../../../../props'
 
 type Props = {
   userAddress: string
   now: string
-  page: number
-  limit: number
-  offset: number
-  orderBy: OfferOpenBuysOrderBy
   meta: {
     title: string
     description: string
@@ -78,7 +76,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
       : null
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, environment.PAGINATION_LIMIT)
-    const page = getPage(context)
     const orderBy = getOrder<OfferOpenBuysOrderBy>(context, 'CREATED_AT_DESC')
     const offset = getOffset(context, environment.PAGINATION_LIMIT)
     const now = new Date()
@@ -96,10 +93,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     if (!data) throw new Error('data is falsy')
     return {
       props: {
-        page,
-        limit,
-        offset,
-        orderBy,
         userAddress,
         now: now.toJSON(),
         meta: {
@@ -112,20 +105,14 @@ export const getServerSideProps = wrapServerSideProps<Props>(
   },
 )
 
-const BidReceivedPage: NextPage<Props> = ({
-  meta,
-  now,
-  limit,
-  page,
-  offset,
-  orderBy,
-  userAddress,
-}) => {
+const BidReceivedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
   useEagerConnect()
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { replace, pathname, query } = useRouter()
   const { account } = useWeb3React()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<OfferOpenBuysOrderBy>('CREATED_AT_DESC')
   const [changePage, changeLimit] = usePaginate()
   const [accept, { activeStep, transactionHash }] = useAcceptOffer(signer)
   const toast = useToast()

--- a/pages/users/[id]/created.tsx
+++ b/pages/users/[id]/created.tsx
@@ -26,22 +26,18 @@ import {
 } from '../../../graphql'
 import useEagerConnect from '../../../hooks/useEagerConnect'
 import useExecuteOnAccountChange from '../../../hooks/useExecuteOnAccountChange'
+import useOrderByQuery from '../../../hooks/useOrderByQuery'
 import usePaginate from '../../../hooks/usePaginate'
+import usePaginateQuery from '../../../hooks/usePaginateQuery'
 import useSigner from '../../../hooks/useSigner'
 import LargeLayout from '../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../params'
+import { getLimit, getOffset, getOrder } from '../../../params'
 import { wrapServerSideProps } from '../../../props'
 
 type Props = {
   userAddress: string
   currentAccount: string | null
   now: string
-  // Pagination
-  limit: number
-  page: number
-  offset: number
-  // OrderBy
-  orderBy: AssetsOrderBy
   meta: {
     title: string
     description: string
@@ -60,7 +56,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     invariant(userAddress, 'userAddress is falsy')
 
     const limit = getLimit(ctx, environment.PAGINATION_LIMIT)
-    const page = getPage(ctx)
     const orderBy = getOrder<AssetsOrderBy>(ctx, 'CREATED_AT_DESC')
     const offset = getOffset(ctx, environment.PAGINATION_LIMIT)
 
@@ -83,10 +78,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
         userAddress,
         currentAccount: ctx.user.address,
         now: now.toJSON(),
-        limit,
-        page,
-        offset,
-        orderBy,
         meta: {
           title: data.account?.name || userAddress,
           description: data.account?.description || '',
@@ -100,10 +91,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
 const CreatedPage: NextPage<Props> = ({
   meta,
   now,
-  limit,
-  page,
-  offset,
-  orderBy,
   userAddress,
   currentAccount,
 }) => {
@@ -111,6 +98,8 @@ const CreatedPage: NextPage<Props> = ({
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { pathname, replace, query } = useRouter()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<AssetsOrderBy>('CREATED_AT_DESC')
   const [changePage, changeLimit] = usePaginate()
   const { account } = useWeb3React()
 

--- a/pages/users/[id]/offers/auction.tsx
+++ b/pages/users/[id]/offers/auction.tsx
@@ -44,19 +44,17 @@ import {
 } from '../../../../graphql'
 import useBlockExplorer from '../../../../hooks/useBlockExplorer'
 import useEagerConnect from '../../../../hooks/useEagerConnect'
+import useOrderByQuery from '../../../../hooks/useOrderByQuery'
 import usePaginate from '../../../../hooks/usePaginate'
+import usePaginateQuery from '../../../../hooks/usePaginateQuery'
 import useSigner from '../../../../hooks/useSigner'
 import LargeLayout from '../../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../../params'
+import { getLimit, getOffset, getOrder } from '../../../../params'
 import { wrapServerSideProps } from '../../../../props'
 
 type Props = {
   userAddress: string
   now: string
-  page: number
-  limit: number
-  offset: number
-  orderBy: AuctionsOrderBy
   meta: {
     title: string
     description: string
@@ -75,7 +73,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
       : null
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, environment.PAGINATION_LIMIT)
-    const page = getPage(context)
     const orderBy = getOrder<AuctionsOrderBy>(context, 'CREATED_AT_DESC')
     const offset = getOffset(context, environment.PAGINATION_LIMIT)
     const now = new Date()
@@ -93,10 +90,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     if (!data) throw new Error('data is falsy')
     return {
       props: {
-        page,
-        limit,
-        offset,
-        orderBy,
         userAddress,
         now: now.toJSON(),
         meta: {
@@ -109,20 +102,14 @@ export const getServerSideProps = wrapServerSideProps<Props>(
   },
 )
 
-const AuctionPage: NextPage<Props> = ({
-  meta,
-  now,
-  limit,
-  page,
-  offset,
-  orderBy,
-  userAddress,
-}) => {
+const AuctionPage: NextPage<Props> = ({ meta, now, userAddress }) => {
   useEagerConnect()
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { replace, pathname, query } = useRouter()
   const { account } = useWeb3React()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<AuctionsOrderBy>('CREATED_AT_DESC')
   const [changePage, changeLimit] = usePaginate()
   const blockExplorer = useBlockExplorer(
     environment.BLOCKCHAIN_EXPLORER_NAME,

--- a/pages/users/[id]/offers/fixed.tsx
+++ b/pages/users/[id]/offers/fixed.tsx
@@ -47,19 +47,17 @@ import {
 } from '../../../../graphql'
 import useBlockExplorer from '../../../../hooks/useBlockExplorer'
 import useEagerConnect from '../../../../hooks/useEagerConnect'
+import useOrderByQuery from '../../../../hooks/useOrderByQuery'
 import usePaginate from '../../../../hooks/usePaginate'
+import usePaginateQuery from '../../../../hooks/usePaginateQuery'
 import useSigner from '../../../../hooks/useSigner'
 import LargeLayout from '../../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../../params'
+import { getLimit, getOffset, getOrder } from '../../../../params'
 import { wrapServerSideProps } from '../../../../props'
 
 type Props = {
   userAddress: string
   now: string
-  page: number
-  limit: number
-  offset: number
-  orderBy: OffersOrderBy
   meta: {
     title: string
     description: string
@@ -77,7 +75,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
       : null
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, environment.PAGINATION_LIMIT)
-    const page = getPage(context)
     const orderBy = getOrder<OffersOrderBy>(context, 'CREATED_AT_DESC')
     const offset = getOffset(context, environment.PAGINATION_LIMIT)
     const now = new Date()
@@ -95,10 +92,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     if (!data) throw new Error('data is falsy')
     return {
       props: {
-        page,
-        limit,
-        offset,
-        orderBy,
         userAddress,
         now: now.toJSON(),
         meta: {
@@ -111,20 +104,14 @@ export const getServerSideProps = wrapServerSideProps<Props>(
   },
 )
 
-const FixedPricePage: NextPage<Props> = ({
-  meta,
-  now,
-  limit,
-  page,
-  offset,
-  orderBy,
-  userAddress,
-}) => {
+const FixedPricePage: NextPage<Props> = ({ meta, now, userAddress }) => {
   useEagerConnect()
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { replace, pathname, query } = useRouter()
   const { account } = useWeb3React()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<OffersOrderBy>('CREATED_AT_DESC')
   const [changePage, changeLimit] = usePaginate()
   const [cancel, { activeStep, transactionHash }] = useCancelOffer(signer)
   const toast = useToast()

--- a/pages/users/[id]/on-sale.tsx
+++ b/pages/users/[id]/on-sale.tsx
@@ -26,22 +26,18 @@ import {
 } from '../../../graphql'
 import useEagerConnect from '../../../hooks/useEagerConnect'
 import useExecuteOnAccountChange from '../../../hooks/useExecuteOnAccountChange'
+import useOrderByQuery from '../../../hooks/useOrderByQuery'
 import usePaginate from '../../../hooks/usePaginate'
+import usePaginateQuery from '../../../hooks/usePaginateQuery'
 import useSigner from '../../../hooks/useSigner'
 import LargeLayout from '../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../params'
+import { getLimit, getOffset, getOrder } from '../../../params'
 import { wrapServerSideProps } from '../../../props'
 
 type Props = {
   userAddress: string
   currentAccount: string | null
   now: string
-  // Pagination
-  limit: number
-  page: number
-  offset: number
-  // OrderBy
-  orderBy: AssetsOrderBy
   meta: {
     title: string
     description: string
@@ -60,7 +56,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     invariant(userAddress, 'userAddress is falsy')
 
     const limit = getLimit(ctx, environment.PAGINATION_LIMIT)
-    const page = getPage(ctx)
     const orderBy = getOrder<AssetsOrderBy>(ctx, 'CREATED_AT_DESC')
     const offset = getOffset(ctx, environment.PAGINATION_LIMIT)
 
@@ -83,10 +78,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
         userAddress,
         currentAccount: ctx.user.address,
         now: now.toJSON(),
-        limit,
-        page,
-        offset,
-        orderBy,
         meta: {
           title: data.account?.name || userAddress,
           description: data.account?.description || '',
@@ -100,10 +91,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
 const OnSalePage: NextPage<Props> = ({
   meta,
   now,
-  limit,
-  page,
-  offset,
-  orderBy,
   userAddress,
   currentAccount,
 }) => {
@@ -111,6 +98,8 @@ const OnSalePage: NextPage<Props> = ({
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { pathname, replace, query } = useRouter()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<AssetsOrderBy>('CREATED_AT_DESC')
   const [changePage, changeLimit] = usePaginate()
   const { account } = useWeb3React()
 

--- a/pages/users/[id]/owned.tsx
+++ b/pages/users/[id]/owned.tsx
@@ -26,22 +26,18 @@ import {
 } from '../../../graphql'
 import useEagerConnect from '../../../hooks/useEagerConnect'
 import useExecuteOnAccountChange from '../../../hooks/useExecuteOnAccountChange'
+import useOrderByQuery from '../../../hooks/useOrderByQuery'
 import usePaginate from '../../../hooks/usePaginate'
+import usePaginateQuery from '../../../hooks/usePaginateQuery'
 import useSigner from '../../../hooks/useSigner'
 import LargeLayout from '../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../params'
+import { getLimit, getOffset, getOrder } from '../../../params'
 import { wrapServerSideProps } from '../../../props'
 
 type Props = {
   userAddress: string
   currentAccount: string | null
   now: string
-  // Pagination
-  limit: number
-  page: number
-  offset: number
-  // OrderBy
-  orderBy: OwnershipsOrderBy
   meta: {
     title: string
     description: string
@@ -60,7 +56,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     invariant(userAddress, 'userAddress is falsy')
 
     const limit = getLimit(ctx, environment.PAGINATION_LIMIT)
-    const page = getPage(ctx)
     const orderBy = getOrder<OwnershipsOrderBy>(ctx, 'CREATED_AT_DESC')
     const offset = getOffset(ctx, environment.PAGINATION_LIMIT)
 
@@ -83,10 +78,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
         userAddress,
         currentAccount: ctx.user.address,
         now: now.toJSON(),
-        limit,
-        page,
-        offset,
-        orderBy,
         meta: {
           title: data.account?.name || userAddress,
           description: data.account?.description || '',
@@ -100,10 +91,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
 const OwnedPage: NextPage<Props> = ({
   meta,
   now,
-  limit,
-  page,
-  offset,
-  orderBy,
   userAddress,
   currentAccount,
 }) => {
@@ -111,6 +98,8 @@ const OwnedPage: NextPage<Props> = ({
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { pathname, replace, query } = useRouter()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<OwnershipsOrderBy>('CREATED_AT_DESC')
   const [changePage, changeLimit] = usePaginate()
   const { account } = useWeb3React()
 

--- a/pages/users/[id]/trades/purchased.tsx
+++ b/pages/users/[id]/trades/purchased.tsx
@@ -39,19 +39,17 @@ import {
 } from '../../../../graphql'
 import useBlockExplorer from '../../../../hooks/useBlockExplorer'
 import useEagerConnect from '../../../../hooks/useEagerConnect'
+import useOrderByQuery from '../../../../hooks/useOrderByQuery'
 import usePaginate from '../../../../hooks/usePaginate'
+import usePaginateQuery from '../../../../hooks/usePaginateQuery'
 import useSigner from '../../../../hooks/useSigner'
 import LargeLayout from '../../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../../params'
+import { getLimit, getOffset, getOrder } from '../../../../params'
 import { wrapServerSideProps } from '../../../../props'
 
 type Props = {
   userAddress: string
   now: string
-  page: number
-  limit: number
-  offset: number
-  orderBy: TradesOrderBy
   meta: {
     title: string
     description: string
@@ -69,7 +67,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
       : null
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, environment.PAGINATION_LIMIT)
-    const page = getPage(context)
     const orderBy = getOrder<TradesOrderBy>(context, 'TIMESTAMP_DESC')
     const offset = getOffset(context, environment.PAGINATION_LIMIT)
     const now = new Date()
@@ -87,10 +84,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     if (!data.trades) return { notFound: true }
     return {
       props: {
-        page,
-        limit,
-        offset,
-        orderBy,
         userAddress,
         now: now.toJSON(),
         meta: {
@@ -103,19 +96,13 @@ export const getServerSideProps = wrapServerSideProps<Props>(
   },
 )
 
-const TradePurchasedPage: NextPage<Props> = ({
-  meta,
-  now,
-  limit,
-  page,
-  offset,
-  orderBy,
-  userAddress,
-}) => {
+const TradePurchasedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
   useEagerConnect()
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { replace, pathname, query } = useRouter()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<TradesOrderBy>('TIMESTAMP_DESC')
   const [changePage, changeLimit] = usePaginate()
   const { account } = useWeb3React()
   const blockExplorer = useBlockExplorer(

--- a/pages/users/[id]/trades/sold.tsx
+++ b/pages/users/[id]/trades/sold.tsx
@@ -39,19 +39,17 @@ import {
 } from '../../../../graphql'
 import useBlockExplorer from '../../../../hooks/useBlockExplorer'
 import useEagerConnect from '../../../../hooks/useEagerConnect'
+import useOrderByQuery from '../../../../hooks/useOrderByQuery'
 import usePaginate from '../../../../hooks/usePaginate'
+import usePaginateQuery from '../../../../hooks/usePaginateQuery'
 import useSigner from '../../../../hooks/useSigner'
 import LargeLayout from '../../../../layouts/large'
-import { getLimit, getOffset, getOrder, getPage } from '../../../../params'
+import { getLimit, getOffset, getOrder } from '../../../../params'
 import { wrapServerSideProps } from '../../../../props'
 
 type Props = {
   userAddress: string
   now: string
-  page: number
-  limit: number
-  offset: number
-  orderBy: TradesOrderBy
   meta: {
     title: string
     description: string
@@ -69,7 +67,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
       : null
     invariant(userAddress, 'userAddress is falsy')
     const limit = getLimit(context, environment.PAGINATION_LIMIT)
-    const page = getPage(context)
     const orderBy = getOrder<TradesOrderBy>(context, 'TIMESTAMP_DESC')
     const offset = getOffset(context, environment.PAGINATION_LIMIT)
     const now = new Date()
@@ -87,10 +84,6 @@ export const getServerSideProps = wrapServerSideProps<Props>(
     if (!data) throw new Error('data is falsy')
     return {
       props: {
-        page,
-        limit,
-        offset,
-        orderBy,
         userAddress,
         now: now.toJSON(),
         meta: {
@@ -103,19 +96,13 @@ export const getServerSideProps = wrapServerSideProps<Props>(
   },
 )
 
-const TradeSoldPage: NextPage<Props> = ({
-  meta,
-  now,
-  limit,
-  page,
-  offset,
-  orderBy,
-  userAddress,
-}) => {
+const TradeSoldPage: NextPage<Props> = ({ meta, now, userAddress }) => {
   useEagerConnect()
   const signer = useSigner()
   const { t } = useTranslation('templates')
   const { replace, pathname, query } = useRouter()
+  const { limit, offset, page } = usePaginateQuery()
+  const orderBy = useOrderByQuery<TradesOrderBy>('TIMESTAMP_DESC')
   const [changePage, changeLimit] = usePaginate()
   const { account } = useWeb3React()
 


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/starter-kit/issues/168
- Related to the new filter's UI

### Description

The filters introduce new navigation with the [`shallow` option](https://nextjs.org/docs/routing/shallow-routing) that basically changes the URL without having to have a full query on the server side. This is great as it is then faster for the user and has a lot less cloud function consumption.
That said, because of that, a lot of pages that were designed with SSR first approach do not work anymore, and for example, in #168, the pagination was not up to date, and was still getting the initial page from the SSR query.

I moved all the retrieving of pagination and sort (filter was already done) on the client side, this way, all issues are solved, and we can now correctly get the params from SSR or the shallow redirect.

**Note** the last commit, cce46ea88721beb76ed0387d7d3f0045e38c08c4, is not required and can be reverted if it's too much, it's just to ensure that all the codebase is similar and that we will not have an issue in the future

### How to test

The best way is to go on the explore, navigate to the next page, and select a filter. Previously this would not redirect to page 1 or no page, now it should
