### PR TITLE
Optimize images sizes

### DIFF
--- a/components/Collection/CollectionCard.tsx
+++ b/components/Collection/CollectionCard.tsx
@@ -40,6 +40,12 @@ const CollectionCard: FC<Props> = ({ collection }) => {
             alt={collection.name}
             layout="fill"
             objectFit="cover"
+            sizes="
+            429px,
+            (min-width: 30em) 50vw,
+            (min-width: 48em) 33vw,
+            (min-width: 62em) 25vw,
+            (min-width: 80em) 290px"
           />
         )}
         <Box

--- a/components/Collection/CollectionCard.tsx
+++ b/components/Collection/CollectionCard.tsx
@@ -58,7 +58,9 @@ const CollectionCard: FC<Props> = ({ collection }) => {
             <Image
               src={collection.image}
               alt={collection.name}
-              layout="fill"
+              // Twice the image size for better quality
+              width={104}
+              height={104}
               objectFit="cover"
             />
           )}

--- a/components/Collection/CollectionCard.tsx
+++ b/components/Collection/CollectionCard.tsx
@@ -45,7 +45,7 @@ const CollectionCard: FC<Props> = ({ collection }) => {
             (min-width: 30em) 50vw,
             (min-width: 48em) 33vw,
             (min-width: 62em) 25vw,
-            (min-width: 80em) 290px"
+            (min-width: 80em) 292px"
           />
         )}
         <Box

--- a/components/Collection/CollectionCard.tsx
+++ b/components/Collection/CollectionCard.tsx
@@ -41,7 +41,7 @@ const CollectionCard: FC<Props> = ({ collection }) => {
             layout="fill"
             objectFit="cover"
             sizes="
-            429px,
+            100vw,
             (min-width: 30em) 50vw,
             (min-width: 48em) 33vw,
             (min-width: 62em) 25vw,

--- a/components/Collection/CollectionHeader.tsx
+++ b/components/Collection/CollectionHeader.tsx
@@ -134,6 +134,7 @@ const CollectionHeader: FC<Props> = ({ collection, explorer, reportEmail }) => {
             layout="fill"
             objectFit="cover"
             borderRadius={{ base: 0, sm: '2xl' }}
+            sizes="100vw"
           />
         )}
         <Box
@@ -152,7 +153,9 @@ const CollectionHeader: FC<Props> = ({ collection, explorer, reportEmail }) => {
             <Image
               src={collection.image}
               alt={collection.name}
-              layout="fill"
+              // Twice the image size for better quality
+              width={248}
+              height={248}
               objectFit="cover"
             />
           )}

--- a/components/Collection/CollectionHeader.tsx
+++ b/components/Collection/CollectionHeader.tsx
@@ -134,7 +134,7 @@ const CollectionHeader: FC<Props> = ({ collection, explorer, reportEmail }) => {
             layout="fill"
             objectFit="cover"
             borderRadius={{ base: 0, sm: '2xl' }}
-            sizes="100vw"
+            sizes="100vw, (min-width: 80em) 1216px"
           />
         )}
         <Box

--- a/components/Image/Image.tsx
+++ b/components/Image/Image.tsx
@@ -13,6 +13,11 @@ const Image = chakra(NextImage, {
       'placeholder',
       'blurDataURL',
       'loader',
+      'sizes',
+      'priority',
+      'loading',
+      'lazyBoundary',
+      'lazyRoot',
       'unoptimized',
     ].includes(prop),
 })

--- a/components/Notification/Detail.tsx
+++ b/components/Notification/Detail.tsx
@@ -181,7 +181,9 @@ export default function NotificationDetail({
               <Image
                 src={content.image}
                 alt="Square Image"
-                layout="fill"
+                // Twice the image size for better quality
+                width={112}
+                height={112}
                 objectFit="cover"
               />
             </Box>

--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -75,6 +75,12 @@ const TokenMedia: VFC<{
           layout="fill"
           objectFit={fill ? 'cover' : 'scale-down'}
           unoptimized={unlockedContent?.mimetype === 'image/gif'}
+          sizes="
+            429px,
+            (min-width: 30em) 50vw,
+            (min-width: 48em) 33vw,
+            (min-width: 62em) 25vw,
+            (min-width: 80em) 290px"
         />
       </Box>
     )

--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -80,7 +80,7 @@ const TokenMedia: VFC<{
             (min-width: 30em) 50vw,
             (min-width: 48em) 33vw,
             (min-width: 62em) 25vw,
-            (min-width: 80em) 290px"
+            (min-width: 80em) 292px"
         />
       </Box>
     )

--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -76,7 +76,7 @@ const TokenMedia: VFC<{
           objectFit={fill ? 'cover' : 'scale-down'}
           unoptimized={unlockedContent?.mimetype === 'image/gif'}
           sizes="
-            429px,
+            100vw,
             (min-width: 30em) 50vw,
             (min-width: 48em) 33vw,
             (min-width: 62em) 25vw,

--- a/components/User/Profile/Banner.tsx
+++ b/components/User/Profile/Banner.tsx
@@ -31,7 +31,7 @@ const UserProfileBanner: VFC<Props> = ({ cover, image, address, name }) => {
           layout="fill"
           objectFit="cover"
           rounded="xl"
-          sizes="100vw"
+          sizes="100vw, (min-width: 80em) 1216px"
         />
       )}
       <Box

--- a/components/User/Profile/Banner.tsx
+++ b/components/User/Profile/Banner.tsx
@@ -28,10 +28,10 @@ const UserProfileBanner: VFC<Props> = ({ cover, image, address, name }) => {
         <Image
           src={cover}
           alt={name || address}
-          height={200}
-          width={1440}
+          layout="fill"
           objectFit="cover"
           rounded="xl"
+          sizes="100vw"
         />
       )}
       <Box

--- a/components/User/UserCard.tsx
+++ b/components/User/UserCard.tsx
@@ -32,6 +32,12 @@ const UserCard: FC<Props> = ({ user }) => {
               alt={user.name || 'User cover image'}
               layout="fill"
               objectFit="cover"
+              sizes="
+                429px,
+                (min-width: 30em) 50vw,
+                (min-width: 48em) 33vw,
+                (min-width: 62em) 25vw,
+                (min-width: 80em) 290px"
             />
           ) : (
             <Box bg="gray.100" height="full" />

--- a/components/User/UserCard.tsx
+++ b/components/User/UserCard.tsx
@@ -33,7 +33,7 @@ const UserCard: FC<Props> = ({ user }) => {
               layout="fill"
               objectFit="cover"
               sizes="
-                429px,
+                100vw,
                 (min-width: 30em) 50vw,
                 (min-width: 48em) 33vw,
                 (min-width: 62em) 25vw,

--- a/components/User/UserCard.tsx
+++ b/components/User/UserCard.tsx
@@ -37,7 +37,7 @@ const UserCard: FC<Props> = ({ user }) => {
                 (min-width: 30em) 50vw,
                 (min-width: 48em) 33vw,
                 (min-width: 62em) 25vw,
-                (min-width: 80em) 290px"
+                (min-width: 80em) 292px"
             />
           ) : (
             <Box bg="gray.100" height="full" />


### PR DESCRIPTION
Trying to fix image sizes using this PR https://github.com/liteflow-labs/starter-kit/pull/160
Also https://github.com/liteflow-labs/starter-kit/pull/166

- Used chakra breakpoints for sizes that belongs to grid.
- Added `100vw` and `(min-width: 80em) 1216px` for banners
- Used 
```ts
429px, // for mobile //
(min-width: 30em) 50vw,
(min-width: 48em) 33vw,
(min-width: 62em) 25vw,
(min-width: 80em) 290px",
```
- All of the cards using same grid system (collection, token, user card) (4-3-2-1 desktop to mobile), so hardcoding same sizes seems to be the best usage for me

This is a test PR, changes could be added to https://github.com/liteflow-labs/starter-kit/pull/160 as I didn't want to push anything to that. Tried to check and test all `Image` components on the repo