### PR TITLE
invert order in sizes props

### DIFF
--- a/components/Collection/CollectionCard.tsx
+++ b/components/Collection/CollectionCard.tsx
@@ -41,11 +41,11 @@ const CollectionCard: FC<Props> = ({ collection }) => {
             layout="fill"
             objectFit="cover"
             sizes="
-            100vw,
-            (min-width: 30em) 50vw,
-            (min-width: 48em) 33vw,
+            (min-width: 80em) 292px,
             (min-width: 62em) 25vw,
-            (min-width: 80em) 292px"
+            (min-width: 48em) 33vw,
+            (min-width: 30em) 50vw,
+            100vw"
           />
         )}
         <Box

--- a/components/Collection/CollectionHeader.tsx
+++ b/components/Collection/CollectionHeader.tsx
@@ -134,7 +134,9 @@ const CollectionHeader: FC<Props> = ({ collection, explorer, reportEmail }) => {
             layout="fill"
             objectFit="cover"
             borderRadius={{ base: 0, sm: '2xl' }}
-            sizes="100vw, (min-width: 80em) 1216px"
+            sizes="
+            (min-width: 80em) 1216px,
+            100vw"
           />
         )}
         <Box

--- a/components/Token/Card.tsx
+++ b/components/Token/Card.tsx
@@ -161,11 +161,12 @@ const TokenCard: VFC<Props> = ({
             defaultText={asset.name}
             fill={true}
             // sizes determined from the explorer page
-            sizes="100vw,
-            (min-width: 30em) 50vw,
-            (min-width: 48em) 33vw,
+            sizes="
+            (min-width: 80em) 292px,
             (min-width: 62em) 25vw,
-            (min-width: 80em) 292px"
+            (min-width: 48em) 33vw,
+            (min-width: 30em) 50vw,
+            100vw"
           />
         </AspectRatio>
         {auction && (

--- a/components/Token/Header.tsx
+++ b/components/Token/Header.tsx
@@ -102,7 +102,9 @@ const TokenHeader: VFC<Props> = ({
               defaultText={asset.name}
               fill={true}
               // sizes determined from the homepage
-              sizes="100vw, (min-width: 30em) 384px"
+              sizes="
+              (min-width: 30em) 384px,
+              100vw"
             />
           </AspectRatio>
         </Flex>

--- a/components/User/Profile/Banner.tsx
+++ b/components/User/Profile/Banner.tsx
@@ -31,7 +31,9 @@ const UserProfileBanner: VFC<Props> = ({ cover, image, address, name }) => {
           layout="fill"
           objectFit="cover"
           rounded="xl"
-          sizes="100vw, (min-width: 80em) 1216px"
+          sizes="
+          (min-width: 80em) 1216px,
+          100vw"
         />
       )}
       <Box

--- a/components/User/UserCard.tsx
+++ b/components/User/UserCard.tsx
@@ -33,11 +33,11 @@ const UserCard: FC<Props> = ({ user }) => {
               layout="fill"
               objectFit="cover"
               sizes="
-                100vw,
-                (min-width: 30em) 50vw,
-                (min-width: 48em) 33vw,
-                (min-width: 62em) 25vw,
-                (min-width: 80em) 292px"
+              (min-width: 80em) 292px,
+              (min-width: 62em) 25vw,
+              (min-width: 48em) 33vw,
+              (min-width: 30em) 50vw,
+              100vw"
             />
           ) : (
             <Box bg="gray.100" height="full" />

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -318,9 +318,9 @@ const DetailPage: NextPage<Props> = ({
               defaultText={asset.name}
               controls
               sizes="
-              100vw,
+              (min-width: 80em) 500px,
               (min-width: 48em) 50vw,
-              (min-width: 80em) 500px"
+              100vw"
             />
             {asset.hasUnlockableContent && (
               <Flex


### PR DESCRIPTION
### Description

Invert order in sizes props to make the system load the right image size.

On the dev branch, most images are loaded at 3840, the opposite of what the sizes system is about.

With min-width, we need to implement it from larger to smaller.
I guess only the first media query that matched is used, resulting in a wrong value on the dev branch

### How to test

Check the request for image on https://nft-test-polygon-mumbai-git-fix-image-sizes-order-liteflow.vercel.app/

### Checklist

- [x] Base branch of the PR is `dev`
