### PR TITLE
Keep the image ratio in many components

### DIFF
--- a/components/Collection/ListItem.tsx
+++ b/components/Collection/ListItem.tsx
@@ -85,6 +85,7 @@ const CollectionListItem: FC<Props> = ({ collection, ...props }) => {
             alt={collection.name}
             width={32}
             height={32}
+            objectFit="cover"
           />
         ) : (
           <span />

--- a/components/Filter/FilterAsset.tsx
+++ b/components/Filter/FilterAsset.tsx
@@ -246,6 +246,7 @@ const FilterAsset: NextPage<Props> = ({
                     alt={currency.symbol}
                     width={24}
                     height={24}
+                    objectFit="cover"
                   />
                   <Text ml="2">{currency.symbol}</Text>
                 </Flex>
@@ -317,6 +318,7 @@ const FilterAsset: NextPage<Props> = ({
                           alt={currency.symbol}
                           width={24}
                           height={24}
+                          objectFit="cover"
                         />
                       </InputRightElement>
                     </InputGroup>
@@ -372,6 +374,7 @@ const FilterAsset: NextPage<Props> = ({
                             alt={currency.symbol}
                             width={24}
                             height={24}
+                            objectFit="cover"
                           />
                         </InputRightElement>
                       </NumberInput>

--- a/components/Offer/Form/Bid.tsx
+++ b/components/Offer/Form/Bid.tsx
@@ -283,6 +283,7 @@ const OfferFormBid: FC<Props> = (props) => {
               alt={currency.symbol}
               width={24}
               height={24}
+              objectFit="cover"
             />
           </InputRightElement>
         </InputGroup>

--- a/components/Sales/Auction/Form.tsx
+++ b/components/Sales/Auction/Form.tsx
@@ -184,6 +184,7 @@ const SalesAuctionForm: VFC<Props> = ({
                 alt={currency.symbol}
                 width={24}
                 height={24}
+                objectFit="cover"
               />
             </InputRightElement>
           </InputGroup>

--- a/components/Sales/Auction/Inprogress/Inprogress.tsx
+++ b/components/Sales/Auction/Inprogress/Inprogress.tsx
@@ -75,6 +75,7 @@ const SaleAuctionInProgress: VFC<Props> = ({ auction, bestBid }) => {
                 alt={currency.symbol}
                 width={32}
                 height={32}
+                objectFit="cover"
               />
             )}
           </Flex>

--- a/components/Sales/Direct/Form.tsx
+++ b/components/Sales/Direct/Form.tsx
@@ -233,6 +233,7 @@ const SalesDirectForm: VFC<Props> = ({
               alt={currency.symbol}
               width={24}
               height={24}
+              objectFit="cover"
             />
           </InputRightElement>
         </InputGroup>

--- a/components/Sales/Direct/Summary.tsx
+++ b/components/Sales/Direct/Summary.tsx
@@ -53,6 +53,7 @@ const SaleDirectSummary: VFC<Props> = ({ sales, isSingle }) => {
               alt={`${sales[0].currency.symbol} Logo`}
               width={32}
               height={32}
+              objectFit="cover"
             />
           </Box>
         )
@@ -76,6 +77,7 @@ const SaleDirectSummary: VFC<Props> = ({ sales, isSingle }) => {
                   alt={`${x.currency.symbol} Logo`}
                   width={32}
                   height={32}
+                  objectFit="cover"
                 />
               </Box>
             ))}

--- a/components/Sales/Open/Summary.tsx
+++ b/components/Sales/Open/Summary.tsx
@@ -36,6 +36,7 @@ const SaleOpenSummary: VFC<Props> = ({ currencies }) => {
               alt="Currency Logo"
               width={32}
               height={32}
+              objectFit="cover"
             />
           </Flex>
         ))}

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -144,6 +144,7 @@ const Select = <T extends string>({
                           width={24}
                           height={24}
                           alt={selectedChoice.value}
+                          objectFit="cover"
                         />
                       </Box>
                     )}
@@ -197,6 +198,7 @@ const Select = <T extends string>({
                             width={24}
                             height={24}
                             alt={choice.value}
+                            objectFit="cover"
                           />
                         </Box>
                       )}

--- a/components/Wallet/Account/WalletBalanceList.tsx
+++ b/components/Wallet/Account/WalletBalanceList.tsx
@@ -31,7 +31,15 @@ const WalletBalanceList: VFC<IProps> = ({ account, currencies }) => {
           as={ListItem}
           key={x.id}
           withSeparator={i < currenciesArr.length - 1}
-          image={<Image src={x.image} width={40} height={40} alt={x.symbol} />}
+          image={
+            <Image
+              src={x.image}
+              width={40}
+              height={40}
+              alt={x.symbol}
+              objectFit="cover"
+            />
+          }
           label={x.name}
           action={
             <Text as="span" color="brand.black" fontWeight="medium">

--- a/components/Wallet/Image.tsx
+++ b/components/Wallet/Image.tsx
@@ -29,6 +29,7 @@ const AccountImage: VFC<{
       alt={address}
       width={size || defaultSize}
       height={size || defaultSize}
+      objectFit="cover"
       {...props}
     />
   )

--- a/pages/checkout/[id].tsx
+++ b/pages/checkout/[id].tsx
@@ -218,6 +218,7 @@ const CheckoutPage: NextPage<Props> = ({
                     alt={`${offer.currency.symbol} Logo`}
                     width={32}
                     height={32}
+                    objectFit="cover"
                   />
                 </Flex>
                 {priceUnit && (

--- a/pages/tokens/[id]/bid.tsx
+++ b/pages/tokens/[id]/bid.tsx
@@ -236,6 +236,7 @@ const BidPage: NextPage<Props> = ({ now, assetId, meta, currentAccount }) => {
                           alt={`${highestBid.currency.symbol} Logo`}
                           width={32}
                           height={32}
+                          objectFit="cover"
                         />
                       </Flex>
                       <Heading as="h2" variant="subtitle" color="brand.black">


### PR DESCRIPTION
### Description

Keep the image ratio in many components by adding the prop:
```
objectFit="cover"
```

Before:
<img width="183" alt="Screenshot 2023-02-09 at 22 05 49" src="https://user-images.githubusercontent.com/5823445/217850416-f375a2c9-bf41-4a03-8b06-ee205392de07.png">


After:
<img width="183" alt="Screenshot 2023-02-09 at 22 06 17" src="https://user-images.githubusercontent.com/5823445/217850577-c590870a-222d-48f9-ae61-603469a061db.png">


### Checklist

- [x] Base branch of the PR is `dev`