### PR TITLE
Revert doubling the image size

### DIFF
--- a/components/Collection/CollectionCard.tsx
+++ b/components/Collection/CollectionCard.tsx
@@ -64,9 +64,8 @@ const CollectionCard: FC<Props> = ({ collection }) => {
             <Image
               src={collection.image}
               alt={collection.name}
-              // Twice the image size for better quality
-              width={104}
-              height={104}
+              width={52}
+              height={52}
               objectFit="cover"
             />
           )}

--- a/components/Collection/CollectionHeader.tsx
+++ b/components/Collection/CollectionHeader.tsx
@@ -153,9 +153,8 @@ const CollectionHeader: FC<Props> = ({ collection, explorer, reportEmail }) => {
             <Image
               src={collection.image}
               alt={collection.name}
-              // Twice the image size for better quality
-              width={248}
-              height={248}
+              width={128}
+              height={128}
               objectFit="cover"
             />
           )}

--- a/components/Notification/Detail.tsx
+++ b/components/Notification/Detail.tsx
@@ -181,9 +181,8 @@ export default function NotificationDetail({
               <Image
                 src={content.image}
                 alt="Square Image"
-                // Twice the image size for better quality
-                width={112}
-                height={112}
+                width={56}
+                height={56}
                 objectFit="cover"
               />
             </Box>


### PR DESCRIPTION
### Project organization

- Closes <!-- add link to issue that this PR fixes if any -->
- Related https://github.com/liteflow-labs/starter-kit/pull/170/files#r1101170738
- Dependant on <!-- add link to dependant PR if any -->

### Description

Revert doubling the image size in 3 components.

It's not up to us to try to improve what the next/image component image rendering process is doing.
Moreover, why changing it in only 3 places? This quality degradation is present everywhere.
I feel this is the start of a rabbit hole of optimising the quality of all images.
The goal was the opposite: reducing the image load speed by loading smaller, less quality, images.

I try to set the quality prop to 100 to see if it make a big difference. I can see only a slight quality increase. You can check it on the collection's square image with this preview: https://nft-test-polygon-mumbai-fihqdgrot-liteflow.vercel.app/collection/80001/0x7c68c3c59ceb245733a2fdeb47f5f7d6dbcc65b3
I don't think it's worth it to change this quality prop. Let's implement correctly the tool we have, but keep the default values as much as possible.

### How to test

<!-- A concise explanation how to test this PR with links -->

### Checklist

- [x] Base branch of the PR is `dev`
