### PR TITLE
Normalize import of useAccount from Wagmi

### DIFF
--- a/components/Wallet/Connectors/_base.tsx
+++ b/components/Wallet/Connectors/_base.tsx
@@ -1,6 +1,6 @@
 import { Box, BoxProps, Spinner, Text } from '@chakra-ui/react'
 import { SyntheticEvent, useMemo, useState, VFC } from 'react'
-import { Connector, useAccount as useOriginalAccount, useConnect } from 'wagmi'
+import { Connector, useAccount as useWagmiAccount, useConnect } from 'wagmi'
 import useAccount from '../../../hooks/useAccount'
 
 type Props = Omit<BoxProps, 'onError'> & {
@@ -20,7 +20,7 @@ const WalletBase: VFC<Props> = ({
   ...props
 }) => {
   const { isConnected, isLoggedIn } = useAccount()
-  const { connector: connectedConnector } = useOriginalAccount()
+  const { connector: connectedConnector } = useWagmiAccount()
   const { connectAsync } = useConnect()
   const [isLoading, setIsLoading] = useState(false)
 

--- a/hooks/useEagerConnect.ts
+++ b/hooks/useEagerConnect.ts
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
-import { useAccount as useOriginalAccount } from 'wagmi'
+import { useAccount as useWagmiAccount } from 'wagmi'
 import useAccount from './useAccount'
 
 export default function useEagerConnect(): boolean {
-  const { isReconnecting } = useOriginalAccount()
+  const { isReconnecting } = useWagmiAccount()
   const { isConnected, isLoggedIn } = useAccount()
   const [hasBeenReady, setHasBeenReady] = useState(false)
 


### PR DESCRIPTION
### Description

Replace import of `useAccount` from `wagmi` when named `useOriginalAccount` by `useWagmiAccount` to normalized the codebase

### Checklist

- [x] Base branch of the PR is `dev`