### PR TITLE
require `onActivate` and `onError` callbacks on wallet components

### DIFF
--- a/components/Login/Form.tsx
+++ b/components/Login/Form.tsx
@@ -33,7 +33,7 @@ const LoginForm: FC<Props> = ({ onActivate }) => {
           _hover={{ shadow: 'md' }}
           transition="box-shadow 0.3s ease-in-out"
         >
-          <WalletEmail onActivate={onActivate} />
+          <WalletEmail onActivate={onActivate} onError={setErrorFromLogin} />
         </Stack>
       )}
       {connectors.email && hasStandardWallet && (

--- a/components/Wallet/Connectors/Coinbase.tsx
+++ b/components/Wallet/Connectors/Coinbase.tsx
@@ -4,8 +4,8 @@ import { connectors } from '../../../connectors'
 import WalletBase from './_base'
 
 type Props = {
-  onError?: (error?: Error) => void
-  onActivate?: () => void
+  onError: (error: Error) => void
+  onActivate: (() => void) | undefined
 }
 
 export const IconCoinbase = (

--- a/components/Wallet/Connectors/Email.tsx
+++ b/components/Wallet/Connectors/Email.tsx
@@ -5,8 +5,8 @@ import { connectors } from '../../../connectors'
 import WalletBase from './_base'
 
 type Props = {
-  onError?: (error?: Error) => void
-  onActivate?: () => void
+  onError: (error: Error) => void
+  onActivate: (() => void) | undefined
 }
 
 const IconMagic = (

--- a/components/Wallet/Connectors/Metamask.tsx
+++ b/components/Wallet/Connectors/Metamask.tsx
@@ -4,8 +4,8 @@ import { connectors } from '../../../connectors'
 import WalletBase from './_base'
 
 type Props = {
-  onError?: (error?: Error) => void
-  onActivate?: () => void
+  onError: (error: Error) => void
+  onActivate: (() => void) | undefined
 }
 
 export const IconMetamask = (

--- a/components/Wallet/Connectors/WalletConnect.tsx
+++ b/components/Wallet/Connectors/WalletConnect.tsx
@@ -4,8 +4,8 @@ import { connectors } from '../../../connectors'
 import WalletBase from './_base'
 
 type Props = {
-  onError?: (error?: Error) => void
-  onActivate?: () => void
+  onError: (error: Error) => void
+  onActivate: (() => void) | undefined
 }
 
 export const IconWalletConnect = (

--- a/components/Wallet/Connectors/_base.tsx
+++ b/components/Wallet/Connectors/_base.tsx
@@ -7,8 +7,8 @@ type Props = Omit<BoxProps, 'onError'> & {
   connector: Connector
   name: string
   icon: JSX.Element
-  onActivate?: () => void
-  onError?: (error?: Error) => void
+  onActivate: (() => void) | undefined
+  onError: (error: Error) => void
 }
 
 const WalletBase: VFC<Props> = ({

--- a/components/Wallet/Connectors/_base.tsx
+++ b/components/Wallet/Connectors/_base.tsx
@@ -32,7 +32,7 @@ const WalletBase: VFC<Props> = ({
       await connectAsync({ connector })
       onActivate && onActivate()
     } catch (e) {
-      onError && onError(e as Error)
+      onError(e as Error)
     } finally {
       setIsLoading(false)
     }


### PR DESCRIPTION
- require `onActivate` and `onError` callbacks on wallet components
- add missing `onError` to the WalletEmail