### PR TITLE
Fix the flickering in the navbar when logged in

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -401,12 +401,13 @@ const Navbar: VFC<{
   const [addFund, { loading: addingFund }] = useAddFund(signer)
   const [cookies] = useCookies()
   const lastNotification = cookies[`lastNotification-${address}`]
-  const { data, refetch } = useNavbarAccountQuery({
+  const { data } = useNavbarAccountQuery({
     variables: {
       account: address?.toLowerCase() || '',
       lastNotification: new Date(lastNotification || 0),
     },
     skip: !isLoggedIn,
+    pollInterval: 30_000, // 30 sec
   })
 
   useEffect(() => {
@@ -415,13 +416,6 @@ const Navbar: VFC<{
     if (Array.isArray(query.search)) return setValue('search', '')
     setValue('search', query.search)
   }, [isReady, setValue, query.search])
-
-  useEffect(() => {
-    router.events.on('routeChangeStart', refetch)
-    return () => {
-      router.events.off('routeChangeStart', refetch)
-    }
-  }, [router.events, refetch])
 
   const onSubmit = handleSubmit((data) => {
     if (data.search) query.search = data.search


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/starter-kit/issues/90

### Description

Fix the flickering in the navbar when logged in by implementing a polling of 30sec.
This PR is meant to replace https://github.com/liteflow-labs/starter-kit/pull/187 if you prefer this approach.
The problem with `refetch` is it invalidates the `data` by returning it as `undefined` as soon as refetch is called, even if a previous query was resolved. Polling doesn't have this issue.

### Checklist

- [x] Base branch of the PR is `dev`
