### PR TITLE
Stop to execute Navbar query at every change of page

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -404,8 +404,8 @@ const Navbar: VFC<{
   const {
     data: accountData,
     refetch,
-    previousData: previousAccountData,
-  } = useNavbarAccountQuery({
+  const { data: accountData, previousData: previousAccountData } =
+    useNavbarAccountQuery({
     variables: {
       account: address?.toLowerCase() || '',
       lastNotification: new Date(lastNotification || 0),
@@ -422,13 +422,6 @@ const Navbar: VFC<{
     if (Array.isArray(query.search)) return setValue('search', '')
     setValue('search', query.search)
   }, [isReady, setValue, query.search])
-
-  useEffect(() => {
-    router.events.on('routeChangeStart', refetch)
-    return () => {
-      router.events.off('routeChangeStart', refetch)
-    }
-  }, [router.events, refetch])
 
   const onSubmit = handleSubmit((data) => {
     if (data.search) query.search = data.search

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -36,7 +36,7 @@ import { HiOutlineMenu } from '@react-icons/all-files/hi/HiOutlineMenu'
 import { HiOutlineSearch } from '@react-icons/all-files/hi/HiOutlineSearch'
 import useTranslation from 'next-translate/useTranslation'
 import { MittEmitter } from 'next/dist/shared/lib/mitt'
-import { FC, HTMLAttributes, useEffect, useRef, VFC } from 'react'
+import { FC, HTMLAttributes, useEffect, useMemo, useRef, VFC } from 'react'
 import { useCookies } from 'react-cookie'
 import { useForm } from 'react-hook-form'
 import { useDisconnect } from 'wagmi'
@@ -400,18 +400,18 @@ const Navbar: VFC<{
   const { register, setValue, handleSubmit } = useForm<FormData>()
   const [addFund, { loading: addingFund }] = useAddFund(signer)
   const [cookies] = useCookies()
-  const lastNotification = cookies[`lastNotification-${address}`]
-  const {
-    data: accountData,
-    refetch,
+  const lastNotification = useMemo(
+    () => new Date(cookies[`lastNotification-${address}`] || 0),
+    [address, cookies],
+  )
   const { data: accountData, previousData: previousAccountData } =
     useNavbarAccountQuery({
-    variables: {
-      account: address?.toLowerCase() || '',
-      lastNotification: new Date(lastNotification || 0),
-    },
-    skip: !isLoggedIn,
-  })
+      variables: {
+        account: address?.toLowerCase() || '',
+        lastNotification: lastNotification,
+      },
+      skip: !isLoggedIn,
+    })
   const account = isLoggedIn
     ? accountData?.account || previousAccountData?.account
     : undefined


### PR DESCRIPTION
### Project management

Based on https://github.com/liteflow-labs/starter-kit/pull/187

### Description

I'm trying to understand why the Navbar query is executed at every page change when the user is logged in.
This query is still executed at every page change even with the following modifications:
- remove refetch from navbar account query
- put lastNotification in a memo

@antho1404 Any idea where it's coming from?

### Checklist

- [x] Base branch of the PR is `dev`