### PR TITLE
Connection to any network based on the action

### DIFF
--- a/components/Bid/Bid.tsx
+++ b/components/Bid/Bid.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  Divider,
-  Flex,
-  Icon,
-  Text,
-  useDisclosure,
-} from '@chakra-ui/react'
+import { Divider, Flex, Icon, Text, useDisclosure } from '@chakra-ui/react'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber'
 import {
@@ -22,6 +15,7 @@ import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { SyntheticEvent, useMemo, VFC } from 'react'
 import { BlockExplorer } from '../../hooks/useBlockExplorer'
+import ButtonWithNetworkSwitch from '../Button/SwitchNetwork'
 import Link from '../Link/Link'
 import { ListItem } from '../List/List'
 import AcceptOfferModal from '../Modal/AcceptOffer'
@@ -49,6 +43,7 @@ export type Props = {
       verified: boolean
     }
   }
+  chainId: number
   signer: Signer | undefined
   account: string | null | undefined
   blockExplorer: BlockExplorer
@@ -61,6 +56,7 @@ export type Props = {
 
 const Bid: VFC<Props> = ({
   bid,
+  chainId,
   signer,
   account,
   blockExplorer,
@@ -223,7 +219,8 @@ const Bid: VFC<Props> = ({
         action={
           <>
             {canAccept && (
-              <Button
+              <ButtonWithNetworkSwitch
+                chainId={chainId}
                 w={{ base: 'full', md: 'auto' }}
                 isLoading={activeAcceptOfferStep !== AcceptOfferStep.INITIAL}
                 onClick={() =>
@@ -235,10 +232,11 @@ const Bid: VFC<Props> = ({
                 <Text as="span" isTruncated>
                   {t('bid.detail.accept')}
                 </Text>
-              </Button>
+              </ButtonWithNetworkSwitch>
             )}
             {canCancel && (
-              <Button
+              <ButtonWithNetworkSwitch
+                chainId={chainId}
                 variant="outline"
                 colorScheme="gray"
                 w={{ base: 'full', md: 'auto' }}
@@ -248,7 +246,7 @@ const Bid: VFC<Props> = ({
                 <Text as="span" isTruncated>
                   {t('bid.detail.cancel')}
                 </Text>
-              </Button>
+              </ButtonWithNetworkSwitch>
             )}
           </>
         }

--- a/components/Bid/BidList.tsx
+++ b/components/Bid/BidList.tsx
@@ -10,6 +10,7 @@ import Bid from './Bid'
 
 type Props = {
   bids: (BidProps['bid'] & { currency: { id: string } })[]
+  chainId: number
   signer: Signer | undefined
   account: string | null | undefined
   isSingle: boolean
@@ -22,6 +23,7 @@ type Props = {
 
 const BidList: VFC<Props> = ({
   bids,
+  chainId,
   signer,
   account,
   isSingle,
@@ -45,6 +47,7 @@ const BidList: VFC<Props> = ({
           {i > 0 && bids[i - 1]?.currency.id !== bid.currency.id && <hr />}
           <Bid
             bid={bid}
+            chainId={chainId}
             key={bid.id}
             signer={signer}
             account={account}

--- a/components/Button/SwitchNetwork.tsx
+++ b/components/Button/SwitchNetwork.tsx
@@ -1,0 +1,37 @@
+import { Button, ButtonProps } from '@chakra-ui/react'
+import { PropsWithChildren, useCallback } from 'react'
+import { useChainId, useSwitchNetwork } from 'wagmi'
+
+const ButtonWithNetworkSwitch = ({
+  children,
+  chainId,
+  ...props
+}: PropsWithChildren<
+  ButtonProps & {
+    chainId: number
+  }
+>): JSX.Element => {
+  const currentChainId = useChainId()
+  const { switchNetwork } = useSwitchNetwork()
+
+  const handleSwitchNetwork = useCallback(() => {
+    if (!switchNetwork) return
+    switchNetwork()
+  }, [switchNetwork])
+
+  if (currentChainId !== chainId)
+    return (
+      <Button
+        {...props}
+        onClick={handleSwitchNetwork}
+        type="button"
+        leftIcon={undefined}
+        rightIcon={undefined}
+      >
+        Switch Network
+      </Button>
+    )
+
+  return <Button {...props}>{children}</Button>
+}
+export default ButtonWithNetworkSwitch

--- a/components/Offer/Form/Bid.tsx
+++ b/components/Offer/Form/Bid.tsx
@@ -35,6 +35,7 @@ import { FC, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
 import useParseBigNumber from '../../../hooks/useParseBigNumber'
+import ButtonWithNetworkSwitch from '../../Button/SwitchNetwork'
 import Image from '../../Image/Image'
 import CreateOfferModal from '../../Modal/CreateOffer'
 import LoginModal from '../../Modal/Login'
@@ -61,6 +62,7 @@ type Props = {
     name: string
   }[]
   assetId: string
+  chainId: number
   blockExplorer: BlockExplorer
   onCreated: (offerId: string) => void
   auctionId: string | undefined
@@ -86,6 +88,7 @@ const OfferFormBid: FC<Props> = (props) => {
     account,
     currencies,
     assetId,
+    chainId,
     blockExplorer,
     onCreated,
     auctionId,
@@ -397,7 +400,8 @@ const OfferFormBid: FC<Props> = (props) => {
             currency={currency}
             allowTopUp={allowTopUp && ((price && !canBid) || balanceZero)}
           />
-          <Button
+          <ButtonWithNetworkSwitch
+            chainId={chainId}
             disabled={!canBid}
             isLoading={isSubmitting}
             size="lg"
@@ -406,7 +410,7 @@ const OfferFormBid: FC<Props> = (props) => {
             <Text as="span" isTruncated>
               {t('offer.form.bid.submit')}
             </Text>
-          </Button>
+          </ButtonWithNetworkSwitch>
         </>
       ) : (
         <Button size="lg" type="button" onClick={loginOnOpen}>

--- a/components/Offer/Form/Checkout.tsx
+++ b/components/Offer/Form/Checkout.tsx
@@ -28,6 +28,7 @@ import { useForm } from 'react-hook-form'
 import { Offer } from '../../../graphql'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
 import useParseBigNumber from '../../../hooks/useParseBigNumber'
+import ButtonWithNetworkSwitch from '../../Button/SwitchNetwork'
 import AcceptOfferModal from '../../Modal/AcceptOffer'
 import LoginModal from '../../Modal/Login'
 import Balance from '../../User/Balance'
@@ -41,6 +42,7 @@ type Props = {
   signer: Signer | undefined
   account: string | null | undefined
   offer: Pick<Offer, 'id' | 'unitPrice' | 'availableQuantity'>
+  chainId: number
   blockExplorer: BlockExplorer
   currency: {
     id: string
@@ -59,6 +61,7 @@ const OfferFormCheckout: FC<Props> = ({
   onPurchased,
   multiple,
   offer,
+  chainId,
   blockExplorer,
   allowTopUp,
 }) => {
@@ -205,7 +208,8 @@ const OfferFormCheckout: FC<Props> = ({
         </Box>
       </Alert>
       {account ? (
-        <Button
+        <ButtonWithNetworkSwitch
+          chainId={chainId}
           disabled={!!account && !canPurchase}
           isLoading={isSubmitting}
           size="lg"
@@ -214,7 +218,7 @@ const OfferFormCheckout: FC<Props> = ({
           <Text as="span" isTruncated>
             {t('offer.form.checkout.submit')}
           </Text>
-        </Button>
+        </ButtonWithNetworkSwitch>
       ) : (
         <Button size="lg" type="button" onClick={loginOnOpen}>
           <Text as="span" isTruncated>

--- a/components/Sales/Auction/Info.tsx
+++ b/components/Sales/Auction/Info.tsx
@@ -15,12 +15,14 @@ import { HiArrowNarrowRight } from '@react-icons/all-files/hi/HiArrowNarrowRight
 import useTranslation from 'next-translate/useTranslation'
 import { ReactElement, useCallback, useMemo, useState, VFC } from 'react'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
+import ButtonWithNetworkSwitch from '../../Button/SwitchNetwork'
 import Link from '../../Link/Link'
 import AcceptAuctionModal from '../../Modal/AcceptAuction'
 import Price from '../../Price/Price'
 
 export type Props = {
   assetId: string
+  chainId: number
   auction: {
     id: string
     reserveAmount: BigNumber
@@ -44,6 +46,7 @@ export type Props = {
 const SaleAuctionInfo: VFC<Props> = ({
   signer,
   assetId,
+  chainId,
   auction,
   isOwner,
   isHomepage,
@@ -103,15 +106,20 @@ const SaleAuctionInfo: VFC<Props> = ({
         type: 'success',
         icon: <Icon as={BiBadgeCheck} h={6} w={6} color="white" />,
         title: t('sales.auction.info.no-bids.title'),
-        action: {
-          children: (
+        action: (
+          <Button
+            as={Link}
+            variant="outline"
+            colorScheme="gray"
+            bgColor="white"
+            href={`/tokens/${assetId}/offer`}
+            rightIcon={<HiArrowNarrowRight />}
+          >
             <Text as="span" isTruncated>
               {t('sales.auction.info.no-bids.action')}
             </Text>
-          ),
-          href: `/tokens/${assetId}/offer`,
-          rightIcon: <HiArrowNarrowRight />,
-        },
+          </Button>
+        ),
       }
     }
     if (endedWithNoReserve) {
@@ -119,15 +127,20 @@ const SaleAuctionInfo: VFC<Props> = ({
         type: 'success',
         icon: <Icon as={BiBadgeCheck} h={6} w={6} color="white" />,
         title: t('sales.auction.info.no-reserve.title'),
-        action: {
-          children: (
+        action: (
+          <Button
+            as={Link}
+            variant="outline"
+            colorScheme="gray"
+            bgColor="white"
+            href={`/tokens/${assetId}/offer`}
+            rightIcon={<HiArrowNarrowRight />}
+          >
             <Text as="span" isTruncated>
               {t('sales.auction.info.no-reserve.action')}
             </Text>
-          ),
-          href: `/tokens/${assetId}/offer`,
-          rightIcon: <HiArrowNarrowRight />,
-        },
+          </Button>
+        ),
       }
     }
     if (endedWithReserve) {
@@ -135,16 +148,21 @@ const SaleAuctionInfo: VFC<Props> = ({
         type: 'success',
         icon: <Icon as={BiBadgeCheck} h={6} w={6} color="white" />,
         title: t('sales.auction.info.with-reserve.title'),
-        action: {
-          children: (
+        action: (
+          <ButtonWithNetworkSwitch
+            chainId={chainId}
+            variant="outline"
+            colorScheme="gray"
+            bgColor="white"
+            onClick={acceptAuction}
+            isLoading={loading}
+            rightIcon={<HiArrowNarrowRight />}
+          >
             <Text as="span" isTruncated>
               {t('sales.auction.info.with-reserve.action')}
             </Text>
-          ),
-          onClick: acceptAuction,
-          loading: loading,
-          rightIcon: <HiArrowNarrowRight />,
-        },
+          </ButtonWithNetworkSwitch>
+        ),
       }
     }
   }, [
@@ -157,6 +175,7 @@ const SaleAuctionInfo: VFC<Props> = ({
     loading,
     acceptAuction,
     t,
+    chainId,
   ])
 
   if (!isOwner) return null
@@ -188,23 +207,8 @@ const SaleAuctionInfo: VFC<Props> = ({
         </Heading>
       </Flex>
 
-      {info.action?.onClick && (
-        <Button
-          variant="outline"
-          colorScheme="gray"
-          bgColor="white"
-          {...info.action}
-        />
-      )}
-      {info.action?.href && (
-        <Button
-          as={Link}
-          variant="outline"
-          colorScheme="gray"
-          bgColor="white"
-          {...info.action}
-        />
-      )}
+      {info.action}
+
       <AcceptAuctionModal
         isOpen={isOpen}
         onClose={onClose}

--- a/components/Sales/Detail.tsx
+++ b/components/Sales/Detail.tsx
@@ -23,6 +23,7 @@ import SaleOpenSummary from './Open/Summary'
 export type Props = {
   // Asset related props
   assetId: string
+  chainId: number
   blockExplorer: BlockExplorer
   isSingle: boolean
   currencies: SaleOpenSummaryProps['currencies']
@@ -59,6 +60,7 @@ export type Props = {
 
 const SaleDetail: VFC<Props> = ({
   assetId,
+  chainId,
   blockExplorer,
   currencies,
   directSales,
@@ -90,6 +92,7 @@ const SaleDetail: VFC<Props> = ({
           <SaleDirectSummary sales={directSales} isSingle={isSingle} />
           <SaleDirectButton
             assetId={assetId}
+            chainId={chainId}
             sales={directSales}
             blockExplorer={blockExplorer}
             isHomepage={isHomepage}
@@ -100,6 +103,7 @@ const SaleDetail: VFC<Props> = ({
           />
           <SaleDirectInfo
             assetId={assetId}
+            chainId={chainId}
             blockExplorer={blockExplorer}
             signer={signer}
             currentAccount={currentAccount}
@@ -130,6 +134,7 @@ const SaleDetail: VFC<Props> = ({
           />
           <SaleAuctionInfo
             assetId={assetId}
+            chainId={chainId}
             auction={auction}
             signer={signer}
             isOwner={isOwner}

--- a/components/Sales/Direct/Button.tsx
+++ b/components/Sales/Direct/Button.tsx
@@ -10,6 +10,7 @@ import SaleDirectModal from './Modal'
 
 export type Props = {
   assetId: string
+  chainId: number
   blockExplorer: BlockExplorer
   isHomepage: boolean
   sales: ModalProps['sales']
@@ -21,6 +22,7 @@ export type Props = {
 
 const SaleDirectButton: VFC<Props> = ({
   assetId,
+  chainId,
   blockExplorer,
   isHomepage,
   sales,
@@ -69,10 +71,11 @@ const SaleDirectButton: VFC<Props> = ({
         signer={signer}
         currentAccount={currentAccount}
         sales={sales}
+        chainId={chainId}
         onOfferCanceled={onOfferCanceled}
       />
     )
-  }, [sales, currentAccount, signer, onOfferCanceled, blockExplorer])
+  }, [sales, currentAccount, signer, onOfferCanceled, blockExplorer, chainId])
 
   if (ownAllSupply && isHomepage)
     return (

--- a/components/Sales/Direct/Form.tsx
+++ b/components/Sales/Direct/Form.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   FormControl,
   FormErrorMessage,
   FormHelperText,
@@ -36,6 +35,7 @@ import { useForm } from 'react-hook-form'
 import { Standard } from '../../../graphql'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
 import useParseBigNumber from '../../../hooks/useParseBigNumber'
+import ButtonWithNetworkSwitch from '../../Button/SwitchNetwork'
 import Image from '../../Image/Image'
 import CreateOfferModal from '../../Modal/CreateOffer'
 import Price from '../../Price/Price'
@@ -50,6 +50,7 @@ type FormData = {
 
 type Props = {
   assetId: string
+  chainId: number
   standard: Standard
   currencies: {
     name: string
@@ -70,6 +71,7 @@ type Props = {
 
 const SalesDirectForm: VFC<Props> = ({
   assetId,
+  chainId,
   standard,
   currencies,
   feesPerTenThousand,
@@ -444,7 +446,8 @@ const SalesDirectForm: VFC<Props> = ({
         )}
       </Stack>
 
-      <Button
+      <ButtonWithNetworkSwitch
+        chainId={chainId}
         isLoading={activeStep !== CreateOfferStep.INITIAL}
         size="lg"
         type="submit"
@@ -453,7 +456,7 @@ const SalesDirectForm: VFC<Props> = ({
         <Text as="span" isTruncated>
           {t('sales.direct.form.submit')}
         </Text>
-      </Button>
+      </ButtonWithNetworkSwitch>
 
       <CreateOfferModal
         isOpen={isOpen}

--- a/components/Sales/Direct/Info.tsx
+++ b/components/Sales/Direct/Info.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Flex,
   Heading,
   Icon,
@@ -22,12 +21,14 @@ import { HiArrowNarrowRight } from '@react-icons/all-files/hi/HiArrowNarrowRight
 import useTranslation from 'next-translate/useTranslation'
 import { ReactElement, useCallback, useMemo, VFC } from 'react'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
+import ButtonWithNetworkSwitch from '../../Button/SwitchNetwork'
 import CancelOfferModal from '../../Modal/CancelOffer'
 import Price from '../../Price/Price'
 import SaleOpenEdit from '../Open/Info'
 
 export type Props = {
   assetId: string
+  chainId: number
   blockExplorer: BlockExplorer
   isOwner: boolean
   isHomepage: boolean
@@ -51,6 +52,7 @@ export type Props = {
 // TODO: the logic of this component doesn't seems right. The component mostly renders nothing
 const SaleDirectInfo: VFC<Props> = ({
   assetId,
+  chainId,
   blockExplorer,
   isOwner,
   isHomepage,
@@ -134,7 +136,8 @@ const SaleDirectInfo: VFC<Props> = ({
             )}
           </Heading>
         </Flex>
-        <Button
+        <ButtonWithNetworkSwitch
+          chainId={chainId}
           variant="outline"
           colorScheme="gray"
           bgColor="white"
@@ -146,7 +149,7 @@ const SaleDirectInfo: VFC<Props> = ({
           <Text as="span" isTruncated>
             {t('sales.direct.info.cancel')}
           </Text>
-        </Button>
+        </ButtonWithNetworkSwitch>
         <CancelOfferModal
           isOpen={isOpen}
           onClose={onClose}
@@ -167,6 +170,7 @@ const SaleDirectInfo: VFC<Props> = ({
     blockExplorer,
     transactionHash,
     handleCancel,
+    chainId,
   ])
 
   const create = useMemo(() => {

--- a/components/Sales/Direct/Modal.tsx
+++ b/components/Sales/Direct/Modal.tsx
@@ -24,6 +24,7 @@ export type Props = {
   signer: Signer | undefined
   currentAccount: string | null | undefined
   sales: (ItemProps['sale'] & { currency: { id: string } })[]
+  chainId: number
   onOfferCanceled: (id: string) => Promise<void>
 }
 
@@ -32,6 +33,7 @@ const SaleDirectModal: VFC<Props> = ({
   signer,
   currentAccount,
   sales,
+  chainId,
   onOfferCanceled,
 }) => {
   const { t } = useTranslation('components')
@@ -67,6 +69,7 @@ const SaleDirectModal: VFC<Props> = ({
                   )}
                   <SaleDirectModalItem
                     key={sale.id}
+                    chainId={chainId}
                     sale={sale}
                     blockExplorer={blockExplorer}
                     signer={signer}

--- a/components/Sales/Direct/ModalItem.tsx
+++ b/components/Sales/Direct/ModalItem.tsx
@@ -20,6 +20,7 @@ import { HiBadgeCheck } from '@react-icons/all-files/hi/HiBadgeCheck'
 import useTranslation from 'next-translate/useTranslation'
 import { useCallback, VFC } from 'react'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
+import ButtonWithNetworkSwitch from '../../Button/SwitchNetwork'
 import Link from '../../Link/Link'
 import { ListItem } from '../../List/List'
 import CancelOfferModal from '../../Modal/CancelOffer'
@@ -31,6 +32,7 @@ export type Props = {
   blockExplorer: BlockExplorer
   signer: Signer | undefined
   currentAccount: string | null | undefined
+  chainId: number
   sale: {
     id: string
     expiredAt: Date | null | undefined
@@ -53,6 +55,7 @@ export type Props = {
 const SaleDirectModalItem: VFC<Props> = ({
   blockExplorer,
   sale,
+  chainId,
   signer,
   currentAccount,
   onOfferCanceled,
@@ -147,7 +150,8 @@ const SaleDirectModalItem: VFC<Props> = ({
         action={
           !!currentAccount &&
           isSameAddress(sale.maker.address, currentAccount) ? (
-            <Button
+            <ButtonWithNetworkSwitch
+              chainId={chainId}
               variant="outline"
               colorScheme="gray"
               w={{ base: 'full', md: 'auto' }}
@@ -158,7 +162,7 @@ const SaleDirectModalItem: VFC<Props> = ({
               <Text as="span" isTruncated>
                 {t('sales.direct.modal-item.cancel')}
               </Text>
-            </Button>
+            </ButtonWithNetworkSwitch>
           ) : (
             <Button as={Link} href={`/checkout/${sale.id}`}>
               <Text as="span" isTruncated>

--- a/components/Token/Form/Create.tsx
+++ b/components/Token/Form/Create.tsx
@@ -27,6 +27,7 @@ import { FC, useEffect } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
 import { Standard } from '../../../graphql'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
+import ButtonWithNetworkSwitch from '../../Button/SwitchNetwork'
 import Dropzone from '../../Dropzone/Dropzone'
 import CreateCollectibleModal from '../../Modal/CreateCollectible'
 import LoginModal from '../../Modal/Login'
@@ -359,11 +360,15 @@ const TokenFormCreate: FC<Props> = ({
         error={errors.category}
       />
       {signer ? (
-        <Button isLoading={activeStep !== CreateNftStep.INITIAL} type="submit">
+        <ButtonWithNetworkSwitch
+          chainId={collection.chainId}
+          isLoading={activeStep !== CreateNftStep.INITIAL}
+          type="submit"
+        >
           <Text as="span" isTruncated>
             {t('token.form.create.submit')}
           </Text>
-        </Button>
+        </ButtonWithNetworkSwitch>
       ) : (
         <Button type="button" onClick={loginOnOpen}>
           <Text as="span" isTruncated>

--- a/components/Token/Header.tsx
+++ b/components/Token/Header.tsx
@@ -147,6 +147,7 @@ const TokenHeader: VFC<Props> = ({
         <SaleDetail
           blockExplorer={blockExplorer}
           assetId={asset.id}
+          chainId={asset.collection.chainId}
           currencies={chainCurrencies}
           isHomepage={isHomepage}
           isOwner={isOwner}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -24,9 +24,7 @@ import React, {
 import { Cookies, CookiesProvider } from 'react-cookie'
 import {
   useAccount as useWagmiAccount,
-  useChainId,
   useDisconnect,
-  useSwitchNetwork,
   WagmiConfig,
 } from 'wagmi'
 import Banner from '../components/Banner/Banner'
@@ -52,8 +50,6 @@ function Layout({
 }: PropsWithChildren<{ userAddress: string | null }>) {
   const router = useRouter()
   const signer = useSigner()
-  const chainId = useChainId()
-  const { switchNetwork } = useSwitchNetwork({ chainId: environment.CHAIN_ID })
   const userProfileLink = useMemo(
     () => (userAddress ? `/users/${userAddress}` : '/login'),
     [userAddress],
@@ -112,13 +108,6 @@ function Layout({
       { href: 'https://discord.com', label: 'Discord' },
     ].filter(Boolean)
   }, [router.locale, userProfileLink])
-
-  // Automatically switch to the right network
-  useEffect(() => {
-    if (chainId === environment.CHAIN_ID) return
-    if (!switchNetwork) return
-    void switchNetwork()
-  }, [chainId, switchNetwork])
 
   return (
     <ChatWindow>

--- a/pages/checkout/[id].tsx
+++ b/pages/checkout/[id].tsx
@@ -236,6 +236,7 @@ const CheckoutPage: NextPage<Props> = ({
 
             <OfferFormCheckout
               signer={signer}
+              chainId={asset.collection.chainId}
               account={address}
               offer={offer}
               blockExplorer={blockExplorer}

--- a/pages/tokens/[id]/bid.tsx
+++ b/pages/tokens/[id]/bid.tsx
@@ -282,6 +282,7 @@ const BidPage: NextPage<Props> = ({ now, assetId, meta, currentAccount }) => {
                   signer={signer}
                   account={address}
                   assetId={asset.id}
+                  chainId={asset.chainId}
                   multiple={false}
                   owner={asset.ownerships.nodes[0].ownerAddress}
                   currencies={currencies}
@@ -299,6 +300,7 @@ const BidPage: NextPage<Props> = ({ now, assetId, meta, currentAccount }) => {
                 signer={signer}
                 account={address}
                 assetId={asset.id}
+                chainId={asset.chainId}
                 multiple={true}
                 supply={asset.ownerships.aggregates?.sum?.quantity || '0'}
                 currencies={currencies}

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -467,6 +467,7 @@ const DetailPage: NextPage<Props> = ({
           />
           <SaleDetail
             assetId={asset.id}
+            chainId={asset.collection.chainId}
             blockExplorer={blockExplorer}
             currencies={currencies}
             signer={signer}
@@ -562,6 +563,7 @@ const DetailPage: NextPage<Props> = ({
             {(!query.filter || query.filter === AssetTabs.bids) && (
               <BidList
                 bids={bids}
+                chainId={asset.collection.chainId}
                 signer={signer}
                 account={address}
                 isSingle={isSingle}

--- a/pages/tokens/[id]/offer.tsx
+++ b/pages/tokens/[id]/offer.tsx
@@ -222,6 +222,7 @@ const OfferPage: NextPage<Props> = ({ currentAccount, now, assetId, meta }) => {
       return (
         <SalesDirectForm
           assetId={assetId}
+          chainId={asset.chainId}
           standard={asset.collection.standard}
           currencies={currencies}
           blockExplorer={blockExplorer}

--- a/pages/users/[id]/bids/placed.gql
+++ b/pages/users/[id]/bids/placed.gql
@@ -76,6 +76,7 @@ query FetchUserBidsPlaced(
         id
         name
         image
+        chainId
       }
     }
   }

--- a/pages/users/[id]/bids/placed.tsx
+++ b/pages/users/[id]/bids/placed.tsx
@@ -28,6 +28,7 @@ import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
+import ButtonWithNetworkSwitch from '../../../../components/Button/SwitchNetwork'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -321,7 +322,8 @@ const BidPlacedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                       {ownerLoggedIn && (
                         <>
                           {!item.expiredAt || item.expiredAt > new Date() ? (
-                            <Button
+                            <ButtonWithNetworkSwitch
+                              chainId={item.asset.chainId}
                               variant="outline"
                               colorScheme="gray"
                               disabled={activeStep !== CancelOfferStep.INITIAL}
@@ -330,7 +332,7 @@ const BidPlacedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                               <Text as="span" isTruncated>
                                 {t('user.bid-placed.actions.cancel')}
                               </Text>
-                            </Button>
+                            </ButtonWithNetworkSwitch>
                           ) : (
                             <Button
                               as={Link}

--- a/pages/users/[id]/bids/received.gql
+++ b/pages/users/[id]/bids/received.gql
@@ -80,6 +80,7 @@ query FetchUserBidsReceived(
         id
         name
         image
+        chainId
       }
     }
   }

--- a/pages/users/[id]/bids/received.tsx
+++ b/pages/users/[id]/bids/received.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Button,
   Flex,
   Stack,
   Table,
@@ -29,6 +28,7 @@ import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
+import ButtonWithNetworkSwitch from '../../../../components/Button/SwitchNetwork'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -137,6 +137,7 @@ const BidReceivedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
         asset: {
           image: x.asset.image,
           name: x.asset.name,
+          chainId: x.asset.chainId,
         },
       })),
     [data],
@@ -319,7 +320,8 @@ const BidReceivedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                     <Td>{dateFromNow(item.createdAt)}</Td>
                     <Td isNumeric>
                       {ownerLoggedIn && (
-                        <Button
+                        <ButtonWithNetworkSwitch
+                          chainId={item.asset.chainId}
                           variant="outline"
                           colorScheme="gray"
                           disabled={activeStep !== AcceptOfferStep.INITIAL}
@@ -328,7 +330,7 @@ const BidReceivedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                           <Text as="span" isTruncated>
                             {t('user.bid-received.actions.accept')}
                           </Text>
-                        </Button>
+                        </ButtonWithNetworkSwitch>
                       )}
                     </Td>
                   </Tr>

--- a/pages/users/[id]/offers/fixed.gql
+++ b/pages/users/[id]/offers/fixed.gql
@@ -72,6 +72,7 @@ query FetchUserFixedPrice(
         id
         name
         image
+        chainId
         ownerships(filter: { ownerAddress: { equalTo: $address } }) {
           aggregates {
             sum {

--- a/pages/users/[id]/offers/fixed.tsx
+++ b/pages/users/[id]/offers/fixed.tsx
@@ -28,6 +28,7 @@ import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
+import ButtonWithNetworkSwitch from '../../../../components/Button/SwitchNetwork'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -331,7 +332,8 @@ const FixedPricePage: NextPage<Props> = ({ meta, now, userAddress }) => {
                       {ownerLoggedIn && (
                         <>
                           {!item.expiredAt || item.expiredAt > new Date() ? (
-                            <Button
+                            <ButtonWithNetworkSwitch
+                              chainId={item.asset.chainId}
                               variant="outline"
                               colorScheme="gray"
                               disabled={activeStep !== CancelOfferStep.INITIAL}
@@ -340,7 +342,7 @@ const FixedPricePage: NextPage<Props> = ({ meta, now, userAddress }) => {
                               <Text as="span" isTruncated>
                                 {t('user.fixed.actions.cancel')}
                               </Text>
-                            </Button>
+                            </ButtonWithNetworkSwitch>
                           ) : item.ownAsset ? (
                             <Button
                               as={Link}


### PR DESCRIPTION
### Description

Currently, the application is required to be connected to a single network (and enforced by the layout). This PR adds a button wrapper for all actions network dependent on switching to the right network before an action lets the user connect with any chain and execute actions on many different chains.

### How to test

Switch your network to one not "supported" by one of the demo (meaning one network that does not have any collection), then try to execute the following actions:
- Create a listing
- Create a bid
- Accept a bid (from the detail page or account page)
- Cancel a bid (from the detail page or account page)
- Create an auction bid
- Accept an auction
- Create an nft
