### PR TITLE
Switch network with name

### DIFF
--- a/components/Button/SwitchNetwork.tsx
+++ b/components/Button/SwitchNetwork.tsx
@@ -2,6 +2,7 @@ import { Button, ButtonProps, useToast } from '@chakra-ui/react'
 import { formatError } from '@nft/hooks'
 import { PropsWithChildren, useCallback, useEffect } from 'react'
 import { useChainId, useSwitchNetwork } from 'wagmi'
+import { chains } from '../../connectors'
 
 const ButtonWithNetworkSwitch = ({
   children,
@@ -41,7 +42,9 @@ const ButtonWithNetworkSwitch = ({
         rightIcon={undefined}
         isLoading={isLoading}
       >
-        Switch Network
+        Switch to{' '}
+        {chains.find((chain) => chain.id === chainId)?.name ||
+          `network with id ${chainId}`}
       </Button>
     )
 


### PR DESCRIPTION
### Project organization

- Dependant on https://github.com/liteflow-labs/starter-kit/pull/193

### Description

Show the name of the network to switch to in component SwitchNetwork

<img width="503" alt="Screenshot 2023-02-15 at 15 29 33" src="https://user-images.githubusercontent.com/5823445/218973731-b3c57b9e-d34b-409a-80cd-4e9f7bfe16b8.png">

### Checklist

- [x] Base branch of the PR is `dev`