### PR TITLE
Update usage of disable/isDisable

### DIFF
--- a/components/Button/AcceptOffer.tsx
+++ b/components/Button/AcceptOffer.tsx
@@ -52,7 +52,6 @@ export default function AcceptOfferButton({
       <ButtonWithNetworkSwitch
         chainId={chainId}
         {...props}
-        disabled={activeStep !== AcceptOfferStep.INITIAL}
         isLoading={activeStep !== AcceptOfferStep.INITIAL}
         onClick={handleAcceptOffer}
       >

--- a/components/Button/CancelOffer.tsx
+++ b/components/Button/CancelOffer.tsx
@@ -46,7 +46,6 @@ export default function CancelOfferButton({
       <ButtonWithNetworkSwitch
         chainId={chainId}
         {...props}
-        disabled={activeStep !== CancelOfferStep.INITIAL}
         isLoading={activeStep !== CancelOfferStep.INITIAL}
         onClick={handleCancelOffer}
       >

--- a/components/Filter/FilterAsset.tsx
+++ b/components/Filter/FilterAsset.tsx
@@ -206,7 +206,7 @@ const FilterAsset: NextPage<Props> = ({
               {offerTypes.map(({ key, value }) => (
                 <Button
                   key={key}
-                  disabled={isSubmitting}
+                  isDisabled={isSubmitting}
                   variant="outline"
                   size="sm"
                   px={4}
@@ -262,7 +262,7 @@ const FilterAsset: NextPage<Props> = ({
                   }))}
                   value={currency?.id}
                   required
-                  disabled={isSubmitting}
+                  isDisabled={isSubmitting}
                   error={errors.currencyId}
                   onChange={(x: any) => setValue('currencyId', x)}
                   sortAlphabetically
@@ -388,7 +388,10 @@ const FilterAsset: NextPage<Props> = ({
                 </Flex>
               )}
 
-              <Button disabled={isSubmitting} onClick={() => propagateFilter()}>
+              <Button
+                isDisabled={isSubmitting}
+                onClick={() => propagateFilter()}
+              >
                 <Text as="span" isTruncated>
                   {t('filters.assets.submit')}
                 </Text>

--- a/components/Modal/AcceptAuction.tsx
+++ b/components/Modal/AcceptAuction.tsx
@@ -272,7 +272,7 @@ const AcceptAuctionModal: FC<Props> = ({
             colorScheme="gray"
             isFullWidth
             rightIcon={<HiOutlineExternalLink />}
-            disabled={!transactionHash}
+            isDisabled={!transactionHash}
           >
             <Text as="span" isTruncated>
               {t('modal.accept-auction.action', blockExplorer)}

--- a/components/Modal/AcceptOffer.tsx
+++ b/components/Modal/AcceptOffer.tsx
@@ -208,7 +208,7 @@ const AcceptOfferModal: FC<Props> = ({
             colorScheme="gray"
             isFullWidth
             rightIcon={<HiOutlineExternalLink />}
-            disabled={!transactionHash}
+            isDisabled={!transactionHash}
           >
             <Text as="span" isTruncated>
               {step === AcceptOfferStep.APPROVAL_SIGNATURE ||

--- a/components/Modal/CancelOffer.tsx
+++ b/components/Modal/CancelOffer.tsx
@@ -121,7 +121,7 @@ const CancelOfferModal: FC<Props> = ({
             colorScheme="gray"
             isFullWidth
             rightIcon={<HiOutlineExternalLink />}
-            disabled={!transactionHash}
+            isDisabled={!transactionHash}
           >
             <Text as="span" isTruncated>
               {t('modal.cancel-offer.action', blockExplorer)}

--- a/components/Modal/CreateCollectible.tsx
+++ b/components/Modal/CreateCollectible.tsx
@@ -245,7 +245,7 @@ const CreateCollectibleModal: FC<Props> = ({
               colorScheme="gray"
               isFullWidth
               rightIcon={<HiOutlineExternalLink />}
-              disabled={!transactionHash}
+              isDisabled={!transactionHash}
             >
               <Text as="span" isTruncated>
                 {t('modal.create-collectible.action', blockExplorer)}

--- a/components/Modal/CreateOffer.tsx
+++ b/components/Modal/CreateOffer.tsx
@@ -169,7 +169,7 @@ const CreateOfferModal: FC<Props> = ({
             colorScheme="gray"
             isFullWidth
             rightIcon={<HiOutlineExternalLink />}
-            disabled={!transactionHash}
+            isDisabled={!transactionHash}
           >
             <Text as="span" isTruncated>
               {t('modal.create-offer.action', blockExplorer)}

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -360,7 +360,10 @@ const UserMenu: VFC<{
           <MenuItem>{t('navbar.user.edit')}</MenuItem>
         </Link>
         {topUp.allowTopUp && (
-          <MenuItem disabled={topUp.addingFund} onClick={() => topUp.addFund()}>
+          <MenuItem
+            isDisabled={topUp.addingFund}
+            onClick={() => topUp.addFund()}
+          >
             {t('navbar.user.top-up')}
           </MenuItem>
         )}

--- a/components/Offer/Form/Bid.tsx
+++ b/components/Offer/Form/Bid.tsx
@@ -402,7 +402,7 @@ const OfferFormBid: FC<Props> = (props) => {
           />
           <ButtonWithNetworkSwitch
             chainId={chainId}
-            disabled={!canBid}
+            isDisabled={!canBid}
             isLoading={isSubmitting}
             size="lg"
             type="submit"

--- a/components/Offer/Form/Checkout.tsx
+++ b/components/Offer/Form/Checkout.tsx
@@ -210,7 +210,7 @@ const OfferFormCheckout: FC<Props> = ({
       {account ? (
         <ButtonWithNetworkSwitch
           chainId={chainId}
-          disabled={!!account && !canPurchase}
+          isDisabled={!!account && !canPurchase}
           isLoading={isSubmitting}
           size="lg"
           type="submit"

--- a/components/Pagination/Pagination.tsx
+++ b/components/Pagination/Pagination.tsx
@@ -163,7 +163,7 @@ export default function Pagination({
             icon={
               <Icon as={IoChevronBackSharp} h={5} w={5} aria-hidden="true" />
             }
-            disabled={page === 1}
+            isDisabled={page === 1}
             onClick={() => goTo(page - 1)}
           />
           <IconButton
@@ -172,7 +172,7 @@ export default function Pagination({
             rounded="full"
             aria-label="next"
             icon={<Icon as={IoChevronForward} h={5} w={5} aria-hidden="true" />}
-            disabled={page === totalPage}
+            isDisabled={page === totalPage}
             onClick={() => goTo(page + 1)}
           />
         </Flex>

--- a/components/Sales/Auction/Action.tsx
+++ b/components/Sales/Auction/Action.tsx
@@ -77,7 +77,6 @@ const SaleAuctionAction: VFC<Props> = ({
       return (
         <Button
           isLoading={activeStep !== AcceptAuctionStep.INITIAL}
-          disabled={activeStep !== AcceptAuctionStep.INITIAL}
           onClick={() => handleAcceptAuction(auction.id)}
         >
           <Text as="span" isTruncated>

--- a/components/Sales/Direct/Info.tsx
+++ b/components/Sales/Direct/Info.tsx
@@ -6,7 +6,7 @@ import {
   Stack,
   Text,
   useDisclosure,
-  useToast
+  useToast,
 } from '@chakra-ui/react'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
@@ -14,7 +14,7 @@ import {
   CancelOfferStep,
   formatError,
   isSameAddress,
-  useCancelOffer
+  useCancelOffer,
 } from '@nft/hooks'
 import { BiBadgeCheck } from '@react-icons/all-files/bi/BiBadgeCheck'
 import { HiArrowNarrowRight } from '@react-icons/all-files/hi/HiArrowNarrowRight'

--- a/components/Sales/Direct/Info.tsx
+++ b/components/Sales/Direct/Info.tsx
@@ -6,7 +6,7 @@ import {
   Stack,
   Text,
   useDisclosure,
-  useToast,
+  useToast
 } from '@chakra-ui/react'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
@@ -14,7 +14,7 @@ import {
   CancelOfferStep,
   formatError,
   isSameAddress,
-  useCancelOffer,
+  useCancelOffer
 } from '@nft/hooks'
 import { BiBadgeCheck } from '@react-icons/all-files/bi/BiBadgeCheck'
 import { HiArrowNarrowRight } from '@react-icons/all-files/hi/HiArrowNarrowRight'
@@ -144,7 +144,6 @@ const SaleDirectInfo: VFC<Props> = ({
           onClick={() => handleCancel(currentAccountFirstSale)}
           rightIcon={<HiArrowNarrowRight />}
           isLoading={activeStep !== CancelOfferStep.INITIAL}
-          disabled={activeStep !== CancelOfferStep.INITIAL}
         >
           <Text as="span" isTruncated>
             {t('sales.direct.info.cancel')}

--- a/components/Sales/Direct/ModalItem.tsx
+++ b/components/Sales/Direct/ModalItem.tsx
@@ -5,7 +5,7 @@ import {
   Icon,
   Text,
   useDisclosure,
-  useToast,
+  useToast
 } from '@chakra-ui/react'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
@@ -14,7 +14,7 @@ import {
   formatDate,
   formatError,
   isSameAddress,
-  useCancelOffer,
+  useCancelOffer
 } from '@nft/hooks'
 import { HiBadgeCheck } from '@react-icons/all-files/hi/HiBadgeCheck'
 import useTranslation from 'next-translate/useTranslation'

--- a/components/Sales/Direct/ModalItem.tsx
+++ b/components/Sales/Direct/ModalItem.tsx
@@ -5,7 +5,7 @@ import {
   Icon,
   Text,
   useDisclosure,
-  useToast
+  useToast,
 } from '@chakra-ui/react'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
@@ -14,7 +14,7 @@ import {
   formatDate,
   formatError,
   isSameAddress,
-  useCancelOffer
+  useCancelOffer,
 } from '@nft/hooks'
 import { HiBadgeCheck } from '@react-icons/all-files/hi/HiBadgeCheck'
 import useTranslation from 'next-translate/useTranslation'

--- a/components/Sales/Direct/ModalItem.tsx
+++ b/components/Sales/Direct/ModalItem.tsx
@@ -157,7 +157,6 @@ const SaleDirectModalItem: VFC<Props> = ({
               w={{ base: 'full', md: 'auto' }}
               onClick={() => handleCancel()}
               isLoading={activeStep !== CancelOfferStep.INITIAL}
-              disabled={activeStep !== CancelOfferStep.INITIAL}
             >
               <Text as="span" isTruncated>
                 {t('sales.direct.modal-item.cancel')}

--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -32,7 +32,7 @@ type IProps<T extends string> = HTMLAttributes<any> & {
   }[]
   value?: T
   onChange?(value: string | string[] | undefined): void
-  disabled?: boolean
+  isDisabled?: boolean
   error?: FieldError | undefined
   name: string
   hint?: string
@@ -52,6 +52,7 @@ const Select = <T extends string>({
   placeholder,
   error,
   onChange,
+  isDisabled,
   name,
   hint,
   required,
@@ -108,17 +109,9 @@ const Select = <T extends string>({
               px={4}
               py={2}
               borderWidth="1px"
-              color={
-                props.disabled ? 'gray.500' : !error ? 'brand.black' : 'red.900'
-              }
-              bgColor={props.disabled ? 'gray.100' : 'white'}
+              color={error ? 'red.900' : 'brand.black'}
               w={selectWidth ? selectWidth : 'full'}
-              shadow={props.disabled ? undefined : 'sm'}
-              pointerEvents={props.disabled ? 'none' : undefined}
               borderColor={!error ? 'gray.200' : 'red.300'}
-              _hover={{
-                shadow: props.disabled ? undefined : 'md',
-              }}
               _focus={{
                 ring: 1,
                 ringColor: !error ? 'brand.500' : 'red.500',
@@ -126,6 +119,7 @@ const Select = <T extends string>({
                 outline: 'none',
               }}
               rightIcon={<Icon w={5} h={5} as={HiChevronDown} />}
+              isDisabled={isDisabled}
             >
               <Flex align="center" gap={2}>
                 {selectedChoice ? (


### PR DESCRIPTION
### Project organization
- Related to comments on https://github.com/liteflow-labs/starter-kit/pull/199#discussion_r1108144719

### Changes
- Replace `disabled` with `isDisabled`
- Remove disabled styles from `<Select />` component, as Chakra already applies those and instead use `isDisabled`
- Remove `disabled` props if it's same with `isLoading`, as both doing the same thing

### Description
As Chakra UI discourages to use `disabled` prop, instead we should use `isDisabled` prop.

### Checklist
- [x] Base branch of the PR is `dev`
