### PR TITLE
Improve apollo client initialization

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -197,9 +197,10 @@ function AccountProvider(
     [jwtToken],
   )
 
-  useEffect(() => {
-    client.restore(props.cache)
-  }, [client, props.cache])
+  // Restore cache on when the cache prop changes
+  useEffect(() => void client.restore(props.cache), [client, props.cache])
+  // Reset the store when the jwtToken changes
+  useEffect(() => void client.resetStore(), [client, jwtToken])
 
   return <ApolloProvider client={client}>{props.children}</ApolloProvider>
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -191,11 +191,15 @@ function AccountProvider(
               keyFields: ['address'],
             },
           },
-        }).restore(props.cache),
+        }),
         ssrMode: typeof window === 'undefined',
       }),
-    [jwtToken, props.cache],
+    [jwtToken],
   )
+
+  useEffect(() => {
+    client.restore(props.cache)
+  }, [client, props.cache])
 
   return <ApolloProvider client={client}>{props.children}</ApolloProvider>
 }


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/starter-kit/issues/90

### Description

Improve the creation of the apollo client.
Currently the client is recreated for every single page as we update the cache all the time.
This PR makes it so that the client is created based on the user's jwt and never updated, only its cache is updated when navigating

### How to test

You can `console.log` in the `useMemo` of the client, and one best way is to see that during the navigation, the navbar is not flickering anymore as the client stays the same, and so doesn't need refresh

### More improvement

We could still improve the client by initializing it only once. Currently, when the page loads we have a first initialization then when the jwt is ready, the client is recreated. We could have the same logic of creating a base client and only with `useEffect` updating it's state (and resetting its store).