### PR TITLE
Set network to the Magic Connector

### DIFF
--- a/connectors.ts
+++ b/connectors.ts
@@ -1,7 +1,6 @@
 import { MagicConnectConnector } from '@everipedia/wagmi-magic-connector'
 import invariant from 'ts-invariant'
 import {
-  Chain,
   configureChains,
   Connector,
   createClient,
@@ -53,17 +52,22 @@ export const client = createClient({
 function emailConnector(chainId: number) {
   invariant(environment.MAGIC_API_KEY, 'missing MAGIC_API_KEY')
   const rpcUrl = (function () {
-    if (chainId === bscTestnet.id) {
-      return 'https://data-seed-prebsc-1-s1.binance.org:8545/'
+    switch (chainId) {
+      case mainnet.id:
+        return 'https://rpc.ankr.com/eth'
+      case goerli.id:
+        return 'https://rpc.ankr.com/eth_goerli'
+      case polygon.id:
+        return 'https://rpc.ankr.com/polygon'
+      case polygonMumbai.id:
+        return 'https://rpc.ankr.com/polygon_mumbai'
+      case bsc.id:
+        return 'https://rpc.ankr.com/bsc'
+      case bscTestnet.id:
+        return 'https://rpc.ankr.com/bsc_testnet_chapel'
     }
-    const chain: Chain | undefined = chains.find(
-      (chain) => chain.id === chainId,
-    )
-    invariant(chain, `chain with id ${chainId} not found`)
-    const rpcUrl = chain.rpcUrls.default.http[0]
-    invariant(rpcUrl, `no rpcUrl found for chain ${chainId}`)
-    return rpcUrl
   })()
+  invariant(rpcUrl, `no rpcUrl found for chain ${chainId}`)
   return new MagicConnectConnector({
     options: {
       apiKey: environment.MAGIC_API_KEY,

--- a/connectors.ts
+++ b/connectors.ts
@@ -60,8 +60,7 @@ function emailConnector(chainId: number) {
       (chain) => chain.id === chainId,
     )
     invariant(chain, `chain with id ${chainId} not found`)
-    const rpcUrl =
-      chain.rpcUrls['infura']?.http[0] || chain.rpcUrls.default.http[0]
+    const rpcUrl = chain.rpcUrls.default.http[0]
     invariant(rpcUrl, `no rpcUrl found for chain ${chainId}`)
     return rpcUrl
   })()

--- a/connectors.ts
+++ b/connectors.ts
@@ -21,34 +21,15 @@ export const { chains, provider } = configureChains(
   [publicProvider()],
 )
 
-const email = (chainId: number) => {
-  invariant(environment.MAGIC_API_KEY, 'missing MAGIC_API_KEY')
-  const chain: Chain | undefined = chains.find((chain) => chain.id === chainId)
-  invariant(chain, `chain with id ${chainId} not found`)
-  const rpcUrl = chain.rpcUrls.default.http[0]
-  invariant(rpcUrl, `no rpcUrl found for chain ${chainId}`)
-  return new MagicConnectConnector({
-    options: {
-      apiKey: environment.MAGIC_API_KEY,
-      accentColor: theme.colors.brand[500],
-      customHeaderText: 'Acme',
-      magicSdkConfiguration: {
-        network: {
-          rpcUrl,
-          chainId,
-        },
-      },
-    },
-  }) as unknown as Connector
-}
-
 export const connectors: {
   injected?: InjectedConnector
   walletConnect?: WalletConnectConnector
   coinbase?: CoinbaseWalletConnector
   email?: Connector
 } = {
-  email: environment.MAGIC_API_KEY ? email(environment.CHAIN_ID) : undefined,
+  email: environment.MAGIC_API_KEY
+    ? emailConnector(environment.CHAIN_ID)
+    : undefined,
   injected: new InjectedConnector({}),
   walletConnect: new WalletConnectConnector({
     options: { version: '1' },
@@ -68,3 +49,33 @@ export const client = createClient({
     connectors.walletConnect,
   ].filter(Boolean),
 })
+
+function emailConnector(chainId: number) {
+  invariant(environment.MAGIC_API_KEY, 'missing MAGIC_API_KEY')
+  const rpcUrl = (function () {
+    if (chainId === bscTestnet.id) {
+      return 'https://data-seed-prebsc-1-s1.binance.org:8545/'
+    }
+    const chain: Chain | undefined = chains.find(
+      (chain) => chain.id === chainId,
+    )
+    invariant(chain, `chain with id ${chainId} not found`)
+    const rpcUrl =
+      chain.rpcUrls['infura']?.http[0] || chain.rpcUrls.default.http[0]
+    invariant(rpcUrl, `no rpcUrl found for chain ${chainId}`)
+    return rpcUrl
+  })()
+  return new MagicConnectConnector({
+    options: {
+      apiKey: environment.MAGIC_API_KEY,
+      accentColor: theme.colors.brand[500],
+      customHeaderText: 'Acme',
+      magicSdkConfiguration: {
+        network: {
+          rpcUrl,
+          chainId,
+        },
+      },
+    },
+  }) as unknown as Connector
+}

--- a/environment.ts
+++ b/environment.ts
@@ -1,7 +1,7 @@
 import invariant from 'ts-invariant'
 
 type Environment = {
-  MAGIC_API_KEY: string
+  MAGIC_API_KEY?: string
   PUBLIC_ETHEREUM_PROVIDER: string
   GRAPHQL_URL: string
   FEATURED_TOKEN: string[]
@@ -28,9 +28,6 @@ type Environment = {
     address: string
   }[]
 }
-
-// magic api key
-invariant(process.env.NEXT_PUBLIC_MAGIC_API_KEY, 'Missing magic API key')
 
 // ethereum provider
 invariant(


### PR DESCRIPTION
### Description

- Init MagicConnect on a specific network. Use infura or public network from Wagmi config using the `CHAIN_ID` env, except for bsc testnet where the public network is not authorized. Hardcode `https://data-seed-prebsc-1-s1.binance.org:8545` that is authorized.
- Make `NEXT_PUBLIC_MAGIC_API_KEY` env optional. Init the MagicConnector only if this env is set.

### How to test

- Login with MagicConnect on any test marketplace (not using eth mainnet)
- Try to sign a message or a transaction

### Checklist

- [x] Base branch of the PR is `dev`

---

While implementing, I notice network issues depending on the `rpcUrl` passed to MagicConnect.
The rpcUrl's domain must be authorized by Magic our their side (server side).
With the public network from Wagmi, it was not working on all chain. I implement a logic to prefer Infura over public network. I had to hardcode only network for bsc testnet the one from wagmi are not authorized. I would prefer to use Alchemy over Infura but the url authorized for Alchemy are not working

<details>
  <summary>The current allowed list I can see is:</summary>

```
https://*.magic.link/
https://*.fortmatic.com/
https://*.alchemyapi.io/
wss://*.ws.alchemyapi.io/
https://*.infura.io/
https://*.alchemy.com/
https://*.quiknode.pro/
https://*.maticvigil.com/
https://*.binance.org/
https://*.moralis.io/
https://*.matic.network/
https://*.binance.org:8545/
https://gbscache.magic.link/
https://cognito.us-west-2.amazonaws.com/
https://kms.us-west-2.amazonaws.com/
https://cognito-identity.us-west-2.amazonaws.com/
https://*.google.com/
https://www.google-analytics.com/
https://api.segment.io/
https://cdn.segment.com/
https://api.amplitude.com/
https://*.datadoghq.com/
https://*.browser-intake-datadoghq.com/
wss://*.peerjs.com
https://*.launchdarkly.com/
wss://*.bridge.walletconnect.org
https://registry.walletconnect.com/
wss://www.walletlink.org/rpc
https://node1.fairmint.co/
https://beefledgerwallet.com:8544/
https://core.bloxberg.org/
https://node.moonnet.space/
https://goerli.zed.run/
https://rpc.xdaichain.com/
https://matic-mumbai.chainstacklabs.com/
https://api.niftys.com
https://api.staging.niftys.com
https://palm.eth.niftys.com:8545
https://palm-testnet.eth.niftys.com:8545
https://*.palm.niftys.com:8545
wss://*.palm.niftys.com:8546
https://*.rpc.thirdweb.com/
https://*.rpc.cayg.app/
https://rpc.toronto.sx.technology
https://rpc.sx.technology
https://apis.ankr.com/
https://bsc.getblock.io/
https://rpc.ankr.com/
https://*.pokt.network/
https://dblockchain.akru.co
https://blockchain.akru.co
https://avax.getblock.io/
http://localhost:*/
http://127.0.0.1:*/
ws://127.0.0.1:*/
https://evm.cronos.org/
https://evm-t3.cronos.org/
https://*.onflow.org
https://rpc.fragmynt.network/
https://galway-rpc.fragmynt.network/
https://bicon.net.solidwallet.io/
https://ctz.solidwallet.io/
https://berlin.net.solidwallet.io/
https://api.harmony.one/
https://api.s0.t.hmny.io/
https://api.s0.b.hmny.io/
https://tezos-prod.cryptonomic-infra.tech/
https://tezos-dev.cryptonomic-infra.tech/
https://mainnet.api.tez.ie
https://hangzhounet.api.tez.ie
https://ithacanet.ecadinfra.com
wss://rpc.polkadot.io
wss://kusama-rpc.polkadot.io/
https://sokol.poa.network/
https://xdai.poanetwork.dev/
https://*.skalelabs.com
https://*.skale.network
https://*.matic.today/
https://polygon-rpc.com/
https://api.mainnet-beta.solana.com
https://devnet.solana.com
https://api.devnet.solana.com
https://testnet.solana.com
https://api.testnet.solana.com
https://api.zilliqa.com/
https://dev-api.zilliqa.com/
https://api.avax.network/
https://api.avax-test.network/
https://testapi.avax.network
https://dai.poa.network/
https://rpc.gnosischain.com
https://xdai.1hive.org/
https://*.optimism.io
https://alfajores-forno.celo-testnet.org
https://forno.celo.org
https://bsc-dataseed1.defibit.io/
https://bsc-dataseed1.ninicoin.io/
https://*.moonbeam.network
https://rpcapi.fantom.network
https://rpc.testnet.fantom.network/
https://rpc.ftm.tools/
https://*.arbitrum.io/
https://test.confluxrpc.com
https://main.confluxrpc.com
https://stage2-api.zksync.dev/
https://*.telos.net/
https://*.aurora.dev
https://*.metis.io
https://evmexplorer.velas.com/
https://evmexplorer.testnet.velas.com/
https://evmexplorer.devnet.velas.com/
https://arctic-rpc.icenetwork.io:9933
wss://arctic-rpc.icenetwork.io:9944
https://rpc.tst.publicmint.io:8545
https://rpc.publicmint.io:8545
https://exchainrpc.okex.org/
https://*.p2pify.com/
https://*.myhbarwallet.com
https://scoville-rpc.chiliz.com/
https://gwan-ssl.wandevs.org:56891/"
```

</details>
I contacted Magic to ask them to add the RPC urls from Wagmi, let's see if they respond.
