### PR TITLE
Redirect to login page from notification page

### DIFF
--- a/pages/notification.tsx
+++ b/pages/notification.tsx
@@ -28,7 +28,13 @@ export const getServerSideProps = wrapServerSideProps<Props>(
   environment.GRAPHQL_URL,
   async (ctx, client) => {
     const address = ctx.user.address
-    if (!address) return { props: { currentAccount: null } }
+    if (!address)
+      return {
+        redirect: {
+          destination: '/login?redirectTo=notification',
+          permanent: false,
+        },
+      }
 
     const { data, error } = await client.query<GetNotificationsQuery>({
       query: GetNotificationsDocument,


### PR DESCRIPTION
### Project organization
- Closes #76 
- Related to [trello card](https://trello.com/c/5EM3X6gH/520-high-priority-redirect-to-login-instead-of-throwing-error-if-user-is-not-connected-on-template-notification)

### Description
Redirects user to login page if they are not logged in and tries to navigate to notification page. Redirects back to notification after logging in

### How to test
Log out. Go to the url and add `/notification` It should redirect you to login page and after logging in back to notification page.
Also try logging out when on notification page, it should also redirect you to login page again.

### Checklist
- [x] Base branch of the PR is `dev`