### PR TITLE
Card footer overflow added

### DIFF
--- a/components/Sales/Auction/CardFooter.tsx
+++ b/components/Sales/Auction/CardFooter.tsx
@@ -30,36 +30,40 @@ const SaleAuctionCardFooter: VFC<Props> = ({
   return (
     <Flex
       as={Link}
-      color={showButton ? 'white' : 'gray.500'}
-      bgColor={showButton ? 'brand.500' : 'gray.100'}
+      href={`/tokens/${assetId}${!isOwner ? '/bid' : ''}`}
       py={2}
       px={4}
-      fontSize="sm"
-      fontWeight="semibold"
-      href={`/tokens/${assetId}${!isOwner ? '/bid' : ''}`}
+      bgColor={showButton ? 'brand.500' : 'gray.100'}
     >
-      {showButton ? (
-        isOwner ? (
-          t('sales.auction.card-footer.view')
+      <Text
+        variant="subtitle2"
+        color={showButton ? 'white' : 'gray.500'}
+        noOfLines={1}
+        wordBreak="break-all"
+      >
+        {showButton ? (
+          isOwner ? (
+            t('sales.auction.card-footer.view')
+          ) : (
+            t('sales.auction.card-footer.place-bid')
+          )
+        ) : bestBid ? (
+          <>
+            <Text as="span" variant="subtitle2" mr={1}>
+              {t('sales.auction.card-footer.highest-bid')}
+            </Text>
+            <Text
+              as={Price}
+              variant="subtitle2"
+              amount={bestBid.unitPrice}
+              currency={bestBid.currency}
+              color="brand.black"
+            />
+          </>
         ) : (
-          t('sales.auction.card-footer.place-bid')
-        )
-      ) : bestBid ? (
-        <Flex gap={1}>
-          <Text variant="subtitle2">
-            {t('sales.auction.card-footer.highest-bid')}
-          </Text>
-          <Text
-            as={Price}
-            variant="subtitle2"
-            amount={bestBid.unitPrice}
-            currency={bestBid.currency}
-            color="brand.black"
-          />
-        </Flex>
-      ) : (
-        t('sales.auction.card-footer.ongoing-auction')
-      )}
+          t('sales.auction.card-footer.ongoing-auction')
+        )}
+      </Text>
     </Flex>
   )
 }

--- a/components/Sales/Direct/CardFooter.tsx
+++ b/components/Sales/Direct/CardFooter.tsx
@@ -1,4 +1,4 @@
-import { Flex, HStack, Text } from '@chakra-ui/react'
+import { Flex, Text } from '@chakra-ui/react'
 import { BigNumber } from '@ethersproject/bignumber'
 import useTranslation from 'next-translate/useTranslation'
 import { useMemo, VFC } from 'react'
@@ -34,8 +34,8 @@ const SaleDirectCardFooter: VFC<Props> = ({
         return
       case 1:
         return (
-          <HStack spacing={1}>
-            <Text as="span" variant="subtitle2" color="gray.500">
+          <>
+            <Text as="span" variant="subtitle2" color="gray.500" mr={1}>
               {t('sales.direct.card-footer.price')}
             </Text>
             <Text as="span" variant="subtitle2" color="brand.black">
@@ -45,7 +45,7 @@ const SaleDirectCardFooter: VFC<Props> = ({
                 averageFrom={100000}
               />
             </Text>
-          </HStack>
+          </>
         )
       default:
         return hasMultiCurrency ? (
@@ -55,8 +55,8 @@ const SaleDirectCardFooter: VFC<Props> = ({
             })}
           </Text>
         ) : (
-          <HStack spacing={1}>
-            <Text as="span" variant="subtitle2" color="gray.500">
+          <>
+            <Text as="span" variant="subtitle2" color="gray.500" mr={1}>
               {t('sales.direct.card-footer.from')}
             </Text>
             <Text as="span" variant="subtitle2" color="brand.black">
@@ -66,7 +66,7 @@ const SaleDirectCardFooter: VFC<Props> = ({
                 averageFrom={100000}
               />
             </Text>
-          </HStack>
+          </>
         )
     }
   }, [numberOfSales, unitPrice, currency, hasMultiCurrency, t])
@@ -74,19 +74,23 @@ const SaleDirectCardFooter: VFC<Props> = ({
   return (
     <Flex
       as={Link}
-      color={showButton ? 'white' : 'gray.500'}
-      bgColor={showButton ? 'brand.500' : 'gray.100'}
+      href={`/checkout/${saleId}`}
       py={2}
       px={4}
-      fontSize="sm"
-      fontWeight="semibold"
-      href={`/checkout/${saleId}`}
+      bgColor={showButton ? 'brand.500' : 'gray.100'}
     >
-      {showButton
-        ? isOwner
-          ? t('sales.direct.card-footer.view')
-          : t('sales.direct.card-footer.purchase')
-        : chip}
+      <Text
+        variant="subtitle2"
+        color={showButton ? 'white' : 'gray.500'}
+        noOfLines={1}
+        wordBreak="break-all"
+      >
+        {showButton
+          ? isOwner
+            ? t('sales.direct.card-footer.view')
+            : t('sales.direct.card-footer.purchase')
+          : chip}
+      </Text>
     </Flex>
   )
 }

--- a/components/Sales/Open/CardFooter.tsx
+++ b/components/Sales/Open/CardFooter.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text } from '@chakra-ui/react'
+import { Box, Text } from '@chakra-ui/react'
 import { BigNumber } from '@ethersproject/bignumber'
 import useTranslation from 'next-translate/useTranslation'
 import { FC, HTMLAttributes } from 'react'
@@ -29,16 +29,19 @@ const SaleOpenCardFooter: FC<HTMLAttributes<any> & Props> = ({
 }) => {
   const { t } = useTranslation('components')
   return (
-    <Box {...props}>
-      <Flex
-        as={Link}
+    <Box
+      as={Link}
+      href={`/tokens/${assetId}${!isOwner ? '/bid' : ''}`}
+      py={2}
+      px={4}
+      bgColor={showButton ? 'brand.500' : 'gray.100'}
+      {...props}
+    >
+      <Text
+        variant="subtitle2"
         color={showButton ? 'white' : 'gray.500'}
-        bgColor={showButton ? 'brand.500' : 'gray.100'}
-        py={2}
-        px={4}
-        fontSize="sm"
-        fontWeight="semibold"
-        href={`/tokens/${assetId}${!isOwner ? '/bid' : ''}`}
+        noOfLines={1}
+        wordBreak="break-all"
       >
         {showButton ? (
           isOwner ? (
@@ -47,8 +50,8 @@ const SaleOpenCardFooter: FC<HTMLAttributes<any> & Props> = ({
             t('sales.open.card-footer.place-bid')
           )
         ) : bestBid ? (
-          <Flex gap={1}>
-            <Text variant="subtitle2">
+          <>
+            <Text as="span" variant="subtitle2" mr={1}>
               {t('sales.auction.card-footer.highest-bid')}
             </Text>
             <Text
@@ -58,11 +61,11 @@ const SaleOpenCardFooter: FC<HTMLAttributes<any> & Props> = ({
               currency={bestBid.currency}
               color="brand.black"
             />
-          </Flex>
+          </>
         ) : (
           t('sales.open.card-footer.open')
         )}
-      </Flex>
+      </Text>
     </Box>
   )
 }


### PR DESCRIPTION
### Project organization
- Closes #135 
- Related [trello card](https://trello.com/c/WW4W0zqu/561-medium-priority-new-issue-with-the-cards-size-when-switching-languages)

### Description
Adds overflow functionality to token card footers

### How to test
Modify texts on token card footers to get overflow result. No more shifting on the height of the card

### Checklist
- [x] Base branch of the PR is `dev`
