### PR TITLE
Make reserve price optional for auction

### DIFF
--- a/components/Sales/Auction/Form.tsx
+++ b/components/Sales/Auction/Form.tsx
@@ -74,7 +74,6 @@ const SalesAuctionForm: VFC<Props> = ({
     formState: { errors },
   } = useForm<FormData>({
     defaultValues: {
-      price: '0',
       currencyId: currencies[0]?.id,
     },
   })
@@ -162,9 +161,6 @@ const SalesAuctionForm: VFC<Props> = ({
                 placeholder={t('sales.auction.form.price.placeholder')}
                 {...register('price', {
                   validate: (value) => {
-                    if (parseFloat(value) <= 0)
-                      return t('sales.auction.form.validation.positive')
-
                     const nbDecimals = value.split('.')[1]?.length || 0
                     if (nbDecimals > currency.decimals)
                       return t('sales.auction.form.validation.decimals', {

--- a/components/Sales/Auction/Form.tsx
+++ b/components/Sales/Auction/Form.tsx
@@ -111,7 +111,7 @@ const SalesAuctionForm: VFC<Props> = ({
   })
 
   return (
-    <Stack as="form" spacing={8} onSubmit={onSubmit}>
+    <Stack as="form" spacing={8} onSubmit={onSubmit} noValidate>
       <Stack spacing={6}>
         {currencies.length > 1 && (
           <Select
@@ -161,6 +161,8 @@ const SalesAuctionForm: VFC<Props> = ({
                 placeholder={t('sales.auction.form.price.placeholder')}
                 {...register('price', {
                   validate: (value) => {
+                    if (value !== undefined && parseFloat(value) < 0)
+                      return t('sales.auction.form.validation.positive')
                     const nbDecimals = value.split('.')[1]?.length || 0
                     if (nbDecimals > currency.decimals)
                       return t('sales.auction.form.validation.decimals', {

--- a/components/Sales/Auction/Form.tsx
+++ b/components/Sales/Auction/Form.tsx
@@ -111,7 +111,7 @@ const SalesAuctionForm: VFC<Props> = ({
   })
 
   return (
-    <Stack as="form" spacing={8} onSubmit={onSubmit} noValidate>
+    <Stack as="form" spacing={8} onSubmit={onSubmit}>
       <Stack spacing={6}>
         {currencies.length > 1 && (
           <Select


### PR DESCRIPTION
### Project organization
- Closes #147 
- Related [trello card](https://trello.com/c/HwlzcwX4/560-medium-priority-reserve-price-should-be-optional)

### Description
Removes `value=0` validation to make reserve price optional

### How to test
Complete the flow without entering any value on reserve price

### Checklist
- [x] Base branch of the PR is `dev`
