### PR TITLE
Normalize accountImage component usage

### DIFF
--- a/components/Bid/Bid.tsx
+++ b/components/Bid/Bid.tsx
@@ -140,7 +140,7 @@ const Bid: VFC<Props> = ({
               address={bid.maker.address}
               image={bid.maker.image}
               size={40}
-              cursor="pointer"
+              rounded="full"
             />
           </Link>
         }

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -339,15 +339,13 @@ const UserMenu: VFC<{
   return (
     <Menu>
       <MenuButton>
-        <Flex>
-          <Box
-            as={AccountImage}
-            rounded="full"
-            address={user.address || account}
-            image={user.image}
-            size={40}
-          />
-        </Flex>
+        <Flex
+          as={AccountImage}
+          address={user.address || account}
+          image={user.image}
+          size={40}
+          rounded="full"
+        />
       </MenuButton>
       <MenuList>
         <Link href={`/users/${account}`}>

--- a/components/Notification/Detail.tsx
+++ b/components/Notification/Detail.tsx
@@ -190,22 +190,13 @@ export default function NotificationDetail({
         )}
         {/* Fallback to avatar if image is not set but userAddress is set. userImage is optional */}
         {'userAddress' in content && 'userImage' in content && (
-          <div>
-            <Box
-              position="relative"
-              h={14}
-              w={14}
-              overflow="hidden"
-              bgColor="gray.100"
-              rounded="full"
-            >
-              <AccountImage
-                address={content.userAddress}
-                image={content.userImage}
-                size={56}
-              />
-            </Box>
-          </div>
+          <Flex
+            as={AccountImage}
+            address={content.userAddress}
+            image={content.userImage}
+            size={56}
+            rounded="full"
+          />
         )}
         <Box>
           <Text variant="caption" color="brand.black">

--- a/components/Sales/Auction/Incomplete/FailedReservePrice.tsx
+++ b/components/Sales/Auction/Incomplete/FailedReservePrice.tsx
@@ -51,14 +51,11 @@ const SaleAuctionIncompleteReservePrice: VFC<Props> = ({
           {t('sales.auction.failed-no-reserve.highest-bid')}
         </Heading>
         <Flex align="center" gap={3}>
-          <Box
+          <Flex
             as={AccountImage}
-            display="inline-block"
-            h={8}
-            w={8}
-            rounded="full"
             address={bestBid.maker.address}
             image={bestBid.maker.image}
+            rounded="full"
           />
           <Heading as="h4" variant="heading2" color="brand.black">
             <Trans

--- a/components/Sales/Auction/Incomplete/Successfully.tsx
+++ b/components/Sales/Auction/Incomplete/Successfully.tsx
@@ -55,14 +55,11 @@ const SaleAuctionIncompleteSuccess: VFC<Props> = ({
           {t('sales.auction.success.highest-bid')}
         </Heading>
         <Flex align="center" gap={3}>
-          <Box
+          <Flex
             as={AccountImage}
-            display="inline-block"
-            h={8}
-            w={8}
-            rounded="full"
             address={bestBid.maker.address}
             image={bestBid.maker.image}
+            rounded="full"
           />
           <Heading as="h4" variant="heading2" color="brand.black">
             <Trans

--- a/components/Sales/Direct/ModalItem.tsx
+++ b/components/Sales/Direct/ModalItem.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   Flex,
   Icon,
@@ -85,16 +84,14 @@ const SaleDirectModalItem: VFC<Props> = ({
     <>
       <ListItem
         image={
-          <Flex as={Link} href={`/users/${sale.maker.address}`}>
-            <Box
+          <Link href={`/users/${sale.maker.address}`}>
+            <Flex
               as={AccountImage}
               address={sale.maker.address}
               image={sale.maker.image}
               size={40}
-              w={10}
-              h={10}
             />
-          </Flex>
+          </Link>
         }
         label={
           <Flex

--- a/components/Token/Owners/ModalActivator.tsx
+++ b/components/Token/Owners/ModalActivator.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text } from '@chakra-ui/react'
+import { Flex, Text } from '@chakra-ui/react'
 import { ButtonHTMLAttributes, VFC } from 'react'
 import AccountImage from '../../Wallet/Image'
 
@@ -24,26 +24,21 @@ const OwnersModalActivator: VFC<Props> = ({
           ml={index !== 0 ? -3 : undefined}
           title={name ? name : ''}
         >
-          <Box
+          <Flex
             as={AccountImage}
             address={address}
             image={image}
             position="relative"
-            h={8}
-            w={8}
-            overflow="hidden"
             rounded="full"
           />
         </Flex>
       ))}
       {numberOfOwners === 5 && owners[4] && (
         <Flex ml={-3} title={owners[4].name ? owners[4].name : ''}>
-          <Box
+          <Flex
             as={AccountImage}
             address={owners[4].address}
             image={owners[4].image}
-            h={8}
-            w={8}
             rounded="full"
           />
         </Flex>

--- a/components/Token/Owners/ModalItem.tsx
+++ b/components/Token/Owners/ModalItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Icon, Text } from '@chakra-ui/react'
+import { Flex, Icon, Text } from '@chakra-ui/react'
 import { HiBadgeCheck } from '@react-icons/all-files/hi/HiBadgeCheck'
 import useTranslation from 'next-translate/useTranslation'
 import { VFC } from 'react'
@@ -27,13 +27,11 @@ const OwnersModalItem: VFC<Props> = ({
     <Flex as={Link} href={`/users/${address}`}>
       <ListItem
         image={
-          <Box
+          <Flex
             as={AccountImage}
             address={address}
             image={image}
             size={40}
-            h={10}
-            w={10}
             rounded="full"
           />
         }

--- a/components/User/Avatar.tsx
+++ b/components/User/Avatar.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Icon, Text } from '@chakra-ui/react'
+import { Flex, Icon, Text } from '@chakra-ui/react'
 import { HiBadgeCheck } from '@react-icons/all-files/hi/HiBadgeCheck'
 import { VFC } from 'react'
 import Link from '../Link/Link'
@@ -17,14 +17,12 @@ const Avatar: VFC<Props> = ({ address, name, image, verified, size = 8 }) => {
   return (
     <Link display="block" flexShrink={0} href={`/users/${address}`}>
       <Flex align="center" gap={2}>
-        <Box
+        <Flex
           as={AccountImage}
-          rounded="full"
           address={address}
           image={image}
           size={size * 4}
-          w={size}
-          h={size}
+          rounded="full"
         />
         <Text as="span" variant="subtitle2" color="gray.500">
           {name || <WalletAddress address={address} isShort />}

--- a/components/User/Profile/Banner.tsx
+++ b/components/User/Profile/Banner.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex } from '@chakra-ui/react'
+import { Flex } from '@chakra-ui/react'
 import { VFC } from 'react'
 import Image from '../../Image/Image'
 import AccountImage from '../../Wallet/Image'
@@ -36,20 +36,22 @@ const UserProfileBanner: VFC<Props> = ({ cover, image, address, name }) => {
           100vw"
         />
       )}
-      <Box
+      <Flex
         position="absolute"
         bottom={-12}
         left={6}
-        h={24}
-        w={24}
-        overflow="hidden"
         rounded="full"
         borderWidth="4px"
         borderColor="white"
-        bgColor="white"
       >
-        <AccountImage address={address} image={image} size={96} />
-      </Box>
+        <Flex
+          as={AccountImage}
+          address={address}
+          image={image}
+          size={88}
+          rounded="full"
+        />
+      </Flex>
     </Flex>
   )
 }

--- a/components/User/UserCard.tsx
+++ b/components/User/UserCard.tsx
@@ -43,25 +43,22 @@ const UserCard: FC<Props> = ({ user }) => {
           ) : (
             <Box bg="gray.100" height="full" />
           )}
-          <Box
+          <Flex
             position="absolute"
-            bottom={0}
-            transform="translate(1rem, 50%)"
-            border="2px solid"
-            borderColor="white"
+            bottom={-8}
+            left={4}
             rounded="full"
-            w={16}
-            h={16}
+            borderWidth="2px"
+            borderColor="white"
           >
-            <Box
+            <Flex
               as={AccountImage}
               address={user.address}
               image={user.image}
               size={60}
-              objectFit="cover"
               rounded="full"
             />
-          </Box>
+          </Flex>
         </Box>
         <Flex
           alignItems="center"


### PR DESCRIPTION
### Project organization
- Closes #87 
- Related [trello card](https://trello.com/c/z6jv0P5k/518-low-priority-improve-params-of-component-accountimage)

### Description
There has been changes on this component since this issue has been created.
But there were still different kind of usages that wasn't matching rest of the usage.
This PR normalizes the usage of `<AccountImage />` component across the application.

### How to test
Everything should be same, except navbar profile icon positioning and height. (Which wasn't centered before because of the wrong height)

### Checklist
- [x] Base branch of the PR is `dev`
