### PR TITLE
Add empty states for tables

### DIFF
--- a/locales/en/templates.json
+++ b/locales/en/templates.json
@@ -265,7 +265,11 @@
         "item": "Item",
         "price": "Highest bid",
         "status": "Status",
-        "created": "Created"
+        "created": "Created",
+        "empty": {
+          "title": "No Results Found",
+          "description": "Come back later or browse the platform in the meantime"
+        }
       }
     },
     "bid-placed": {
@@ -291,7 +295,11 @@
         "item": "Item",
         "price": "Total Amount",
         "status": "Status",
-        "created": "Placed"
+        "created": "Placed",
+        "empty": {
+          "title": "No Results Found",
+          "description": "Come back later or browse the platform in the meantime"
+        }
       },
       "requested": "{{value}} requested",
       "status": {
@@ -324,7 +332,11 @@
         "item": "Item",
         "price": "Total Amount",
         "from": "Bidder",
-        "created": "Received"
+        "created": "Received",
+        "empty": {
+          "title": "No Results Found",
+          "description": "Come back later or browse the platform in the meantime"
+        }
       },
       "requested": "{{value}} requested",
       "accept": {
@@ -364,7 +376,11 @@
         "item": "Item",
         "price": "Unit price",
         "status": "Status",
-        "created": "Created"
+        "created": "Created",
+        "empty": {
+          "title": "No Results Found",
+          "description": "Come back later or browse the platform in the meantime"
+        }
       },
       "status": {
         "active": "Active",
@@ -409,7 +425,11 @@
         "item": "Item",
         "price": "Total Amount",
         "from": "Seller",
-        "created": "Purchased"
+        "created": "Purchased",
+        "empty": {
+          "title": "No Results Found",
+          "description": "Come back later or browse the platform in the meantime"
+        }
       },
       "purchased": "{{value}} purchased"
     },
@@ -431,7 +451,11 @@
         "item": "Item",
         "price": "Total Amount",
         "to": "Buyer",
-        "created": "Sold"
+        "created": "Sold",
+        "empty": {
+          "title": "No Results Found",
+          "description": "Come back later or browse the platform in the meantime"
+        }
       },
       "sold": "{{value}} sold"
     }

--- a/locales/es-mx/templates.json
+++ b/locales/es-mx/templates.json
@@ -265,7 +265,11 @@
         "item": "Item",
         "price": "Oferta más alta",
         "status": "Estatus",
-        "created": "Creado"
+        "created": "Creado",
+        "empty": {
+          "title": "No Se Han Encontrado Resultados",
+          "description": "Vuelve más tarde o explora la plataforma mientras tanto"
+        }
       }
     },
     "bid-placed": {
@@ -291,7 +295,11 @@
         "item": "Item",
         "price": "Monto Total",
         "status": "Estatus",
-        "created": "Colocada"
+        "created": "Colocada",
+        "empty": {
+          "title": "No Se Han Encontrado Resultados",
+          "description": "Vuelve más tarde o explora la plataforma mientras tanto"
+        }
       },
       "requested": "{{value}} solicitado",
       "status": {
@@ -324,7 +332,11 @@
         "item": "Item",
         "price": "Monto Total",
         "from": "Comprador",
-        "created": "Recibida"
+        "created": "Recibida",
+        "empty": {
+          "title": "No Se Han Encontrado Resultados",
+          "description": "Vuelve más tarde o explora la plataforma mientras tanto"
+        }
       },
       "requested": "{{value}} solicitado",
       "accept": {
@@ -364,7 +376,11 @@
         "item": "Item",
         "price": "Precio (individual)",
         "status": "Estatus",
-        "created": "Creado"
+        "created": "Creado",
+        "empty": {
+          "title": "No Se Han Encontrado Resultados",
+          "description": "Vuelve más tarde o explora la plataforma mientras tanto"
+        }
       },
       "status": {
         "active": "Activa",
@@ -409,7 +425,11 @@
         "item": "Item",
         "price": "Monto Total",
         "from": "Vendedor",
-        "created": "Comprado"
+        "created": "Comprado",
+        "empty": {
+          "title": "No Se Han Encontrado Resultados",
+          "description": "Vuelve más tarde o explora la plataforma mientras tanto"
+        }
       },
       "purchased": "{{value}} comprado"
     },
@@ -431,7 +451,11 @@
         "item": "Item",
         "price": "Monto Total",
         "to": "Comprador",
-        "created": "Vendido"
+        "created": "Vendido",
+        "empty": {
+          "title": "No Se Han Encontrado Resultados",
+          "description": "Vuelve más tarde o explora la plataforma mientras tanto"
+        }
       },
       "sold": "{{value}} vendido"
     }

--- a/locales/ja/templates.json
+++ b/locales/ja/templates.json
@@ -265,7 +265,11 @@
         "item": "アイテム",
         "price": "最高入札額",
         "status": "状態",
-        "created": "作成済"
+        "created": "作成済",
+        "empty": {
+          "title": "結果が見つかりません",
+          "description": "またお越しいただくか、プラットフォームをご覧ください"
+        }
       }
     },
     "bid-placed": {
@@ -291,7 +295,11 @@
         "item": "アイテム",
         "price": "総額",
         "status": "状態",
-        "created": "入札済"
+        "created": "入札済",
+        "empty": {
+          "title": "結果が見つかりません",
+          "description": "またお越しいただくか、プラットフォームをご覧ください"
+        }
       },
       "requested": "{{value}} をリクエスト",
       "status": {
@@ -324,7 +332,11 @@
         "item": "アイテム",
         "price": "総額",
         "from": "入札者",
-        "created": "受取済"
+        "created": "受取済",
+        "empty": {
+          "title": "結果が見つかりません",
+          "description": "またお越しいただくか、プラットフォームをご覧ください"
+        }
       },
       "requested": "{{value}}</> をリクエスト",
       "accept": {
@@ -364,7 +376,11 @@
         "item": "アイテム",
         "price": "ユニット価格",
         "status": "状態",
-        "created": "作成済"
+        "created": "作成済",
+        "empty": {
+          "title": "結果が見つかりません",
+          "description": "またお越しいただくか、プラットフォームをご覧ください"
+        }
       },
       "status": {
         "active": "アクティブ",
@@ -409,7 +425,11 @@
         "item": "アイテム",
         "price": "総額",
         "from": "販売者",
-        "created": "購入済"
+        "created": "購入済",
+        "empty": {
+          "title": "結果が見つかりません",
+          "description": "またお越しいただくか、プラットフォームをご覧ください"
+        }
       },
       "purchased": "{{value}} を購入済"
     },
@@ -431,7 +451,11 @@
         "item": "アイテム",
         "price": "総額",
         "to": "購入者",
-        "created": "販売済"
+        "created": "販売済",
+        "empty": {
+          "title": "結果が見つかりません",
+          "description": "またお越しいただくか、プラットフォームをご覧ください"
+        }
       },
       "sold": "{{value}} 販売済"
     }

--- a/locales/zh-cn/templates.json
+++ b/locales/zh-cn/templates.json
@@ -265,7 +265,11 @@
         "item": "商品",
         "price": "最高出价",
         "status": "状态",
-        "created": "已创建"
+        "created": "已创建",
+        "empty": {
+          "title": "未找到结果",
+          "description": "请稍后再试或在此期间浏览平台"
+        }
       }
     },
     "bid-placed": {
@@ -291,7 +295,11 @@
         "item": "商品",
         "price": "总金额",
         "status": "状态",
-        "created": "已提交"
+        "created": "已提交",
+        "empty": {
+          "title": "未找到结果",
+          "description": "请稍后再试或在此期间浏览平台"
+        }
       },
       "requested": "已请求 {{value}} 件",
       "status": {
@@ -324,7 +332,11 @@
         "item": "商品",
         "price": "总金额",
         "from": "出价者",
-        "created": "已接收"
+        "created": "已接收",
+        "empty": {
+          "title": "未找到结果",
+          "description": "请稍后再试或在此期间浏览平台"
+        }
       },
       "requested": "已请求 {{value}} 件",
       "accept": {
@@ -364,7 +376,11 @@
         "item": "商品",
         "price": "单价",
         "status": "状态",
-        "created": "已创建"
+        "created": "已创建",
+        "empty": {
+          "title": "未找到结果",
+          "description": "请稍后再试或在此期间浏览平台"
+        }
       },
       "status": {
         "active": "激活",
@@ -409,7 +425,11 @@
         "item": "商品",
         "price": "总金额",
         "from": "卖方",
-        "created": "已购买"
+        "created": "已购买",
+        "empty": {
+          "title": "未找到结果",
+          "description": "请稍后再试或在此期间浏览平台"
+        }
       },
       "purchased": "已购买 {{value}} 件"
     },
@@ -431,7 +451,11 @@
         "item": "商品",
         "price": "总金额",
         "to": "买方",
-        "created": "已售出"
+        "created": "已售出",
+        "empty": {
+          "title": "未找到结果",
+          "description": "请稍后再试或在此期间浏览平台"
+        }
       },
       "sold": "已售出 {{value}} 件"
     }

--- a/pages/users/[id]/bids/placed.tsx
+++ b/pages/users/[id]/bids/placed.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   Flex,
+  Icon,
   Stack,
   Table,
   TableContainer,
@@ -15,6 +16,7 @@ import {
   useToast,
 } from '@chakra-ui/react'
 import { dateFromNow, formatError, useIsLoggedIn } from '@nft/hooks'
+import { HiOutlineSearch } from '@react-icons/all-files/hi/HiOutlineSearch'
 import { NextPage } from 'next'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
@@ -22,6 +24,7 @@ import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
 import CancelOfferButton from '../../../../components/Button/CancelOffer'
+import Empty from '../../../../components/Empty/Empty'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -330,6 +333,15 @@ const BidPlacedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                 ))}
               </Tbody>
             </Table>
+            {bids.length === 0 && (
+              <Empty
+                icon={
+                  <Icon as={HiOutlineSearch} w={8} h={8} color="gray.400" />
+                }
+                title={t('user.bid-placed.table.empty.title')}
+                description={t('user.bid-placed.table.empty.description')}
+              />
+            )}
           </TableContainer>
 
           <Pagination

--- a/pages/users/[id]/bids/received.tsx
+++ b/pages/users/[id]/bids/received.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Flex,
+  Icon,
   Stack,
   Table,
   TableContainer,
@@ -11,14 +12,15 @@ import {
   Th,
   Thead,
   Tr,
-  useToast,
+  useToast
 } from '@chakra-ui/react'
 import {
   dateFromNow,
   formatAddress,
   formatError,
-  useIsLoggedIn,
+  useIsLoggedIn
 } from '@nft/hooks'
+import { HiOutlineSearch } from '@react-icons/all-files/hi/HiOutlineSearch'
 import { NextPage } from 'next'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
@@ -26,6 +28,7 @@ import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
 import AcceptOfferButton from '../../../../components/Button/AcceptOffer'
+import Empty from '../../../../components/Empty/Empty'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -39,7 +42,7 @@ import {
   FetchUserBidsReceivedDocument,
   FetchUserBidsReceivedQuery,
   OfferOpenBuysOrderBy,
-  useFetchUserBidsReceivedQuery,
+  useFetchUserBidsReceivedQuery
 } from '../../../../graphql'
 import useAccount from '../../../../hooks/useAccount'
 import useEagerConnect from '../../../../hooks/useEagerConnect'
@@ -316,6 +319,15 @@ const BidReceivedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                 ))}
               </Tbody>
             </Table>
+            {bids.length === 0 && (
+              <Empty
+                icon={
+                  <Icon as={HiOutlineSearch} w={8} h={8} color="gray.400" />
+                }
+                title={t('user.bid-received.table.empty.title')}
+                description={t('user.bid-received.table.empty.description')}
+              />
+            )}
           </TableContainer>
 
           <Pagination

--- a/pages/users/[id]/bids/received.tsx
+++ b/pages/users/[id]/bids/received.tsx
@@ -12,13 +12,13 @@ import {
   Th,
   Thead,
   Tr,
-  useToast
+  useToast,
 } from '@chakra-ui/react'
 import {
   dateFromNow,
   formatAddress,
   formatError,
-  useIsLoggedIn
+  useIsLoggedIn,
 } from '@nft/hooks'
 import { HiOutlineSearch } from '@react-icons/all-files/hi/HiOutlineSearch'
 import { NextPage } from 'next'
@@ -42,7 +42,7 @@ import {
   FetchUserBidsReceivedDocument,
   FetchUserBidsReceivedQuery,
   OfferOpenBuysOrderBy,
-  useFetchUserBidsReceivedQuery
+  useFetchUserBidsReceivedQuery,
 } from '../../../../graphql'
 import useAccount from '../../../../hooks/useAccount'
 import useEagerConnect from '../../../../hooks/useEagerConnect'

--- a/pages/users/[id]/offers/auction.tsx
+++ b/pages/users/[id]/offers/auction.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Flex,
+  Icon,
   Stack,
   Table,
   TableContainer,
@@ -14,12 +15,14 @@ import {
   useToast,
 } from '@chakra-ui/react'
 import { dateFromNow, formatError, useIsLoggedIn } from '@nft/hooks'
+import { HiOutlineSearch } from '@react-icons/all-files/hi/HiOutlineSearch'
 import { NextPage } from 'next'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
+import Empty from '../../../../components/Empty/Empty'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -316,6 +319,15 @@ const AuctionPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                 ))}
               </Tbody>
             </Table>
+            {auctions.length === 0 && (
+              <Empty
+                icon={
+                  <Icon as={HiOutlineSearch} w={8} h={8} color="gray.400" />
+                }
+                title={t('user.auctions.table.empty.title')}
+                description={t('user.auctions.table.empty.description')}
+              />
+            )}
           </TableContainer>
 
           <Pagination

--- a/pages/users/[id]/offers/fixed.tsx
+++ b/pages/users/[id]/offers/fixed.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Button,
   Flex,
+  Icon,
   Stack,
   Table,
   TableContainer,
@@ -15,6 +16,7 @@ import {
   useToast,
 } from '@chakra-ui/react'
 import { dateFromNow, formatError, useIsLoggedIn } from '@nft/hooks'
+import { HiOutlineSearch } from '@react-icons/all-files/hi/HiOutlineSearch'
 import { NextPage } from 'next'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
@@ -22,6 +24,7 @@ import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
 import CancelOfferButton from '../../../../components/Button/CancelOffer'
+import Empty from '../../../../components/Empty/Empty'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -342,6 +345,15 @@ const FixedPricePage: NextPage<Props> = ({ meta, now, userAddress }) => {
                 ))}
               </Tbody>
             </Table>
+            {offers.length === 0 && (
+              <Empty
+                icon={
+                  <Icon as={HiOutlineSearch} w={8} h={8} color="gray.400" />
+                }
+                title={t('user.fixed.table.empty.title')}
+                description={t('user.fixed.table.empty.description')}
+              />
+            )}
           </TableContainer>
 
           <Pagination

--- a/pages/users/[id]/trades/purchased.tsx
+++ b/pages/users/[id]/trades/purchased.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Flex,
+  Icon,
   IconButton,
   Stack,
   Table,
@@ -15,12 +16,14 @@ import {
 } from '@chakra-ui/react'
 import { dateFromNow, formatAddress } from '@nft/hooks'
 import { HiExternalLink } from '@react-icons/all-files/hi/HiExternalLink'
+import { HiOutlineSearch } from '@react-icons/all-files/hi/HiOutlineSearch'
 import { NextPage } from 'next'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
+import Empty from '../../../../components/Empty/Empty'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -315,6 +318,15 @@ const TradePurchasedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                 ))}
               </Tbody>
             </Table>
+            {trades.length === 0 && (
+              <Empty
+                icon={
+                  <Icon as={HiOutlineSearch} w={8} h={8} color="gray.400" />
+                }
+                title={t('user.trade-purchased.table.empty.title')}
+                description={t('user.trade-purchased.table.empty.description')}
+              />
+            )}
           </TableContainer>
 
           <Pagination

--- a/pages/users/[id]/trades/sold.tsx
+++ b/pages/users/[id]/trades/sold.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Flex,
+  Icon,
   IconButton,
   Stack,
   Table,
@@ -15,12 +16,14 @@ import {
 } from '@chakra-ui/react'
 import { dateFromNow, formatAddress } from '@nft/hooks'
 import { HiExternalLink } from '@react-icons/all-files/hi/HiExternalLink'
+import { HiOutlineSearch } from '@react-icons/all-files/hi/HiOutlineSearch'
 import { NextPage } from 'next'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 import invariant from 'ts-invariant'
+import Empty from '../../../../components/Empty/Empty'
 import Head from '../../../../components/Head'
 import Image from '../../../../components/Image/Image'
 import Link from '../../../../components/Link/Link'
@@ -311,6 +314,15 @@ const TradeSoldPage: NextPage<Props> = ({ meta, now, userAddress }) => {
                 ))}
               </Tbody>
             </Table>
+            {trades.length === 0 && (
+              <Empty
+                icon={
+                  <Icon as={HiOutlineSearch} w={8} h={8} color="gray.400" />
+                }
+                title={t('user.trade-sold.table.empty.title')}
+                description={t('user.trade-sold.table.empty.description')}
+              />
+            )}
           </TableContainer>
 
           <Pagination


### PR DESCRIPTION
### Project organization
- Closes #54 
- Related [trello card](https://trello.com/c/9wz4vKzk/524-low-priority-missing-empty-states-for-tables)

### Description
Adds empty states for tables.
Right now all pages use same context
Title ==> `No Results Found`
Description ==> `Come back later or browse the platform in the meantime`
To further enhance, could change texts or add button to redirect if needed.

### How to test
Go to your profile, if you haven't bid / haven't traded / put offer on something, now you should see empty state messages.

### Checklist
- [x] Base branch of the PR is `dev`