### PR TITLE
Checkbox component isChecked case fix

### DIFF
--- a/components/Filter/FilterAsset.tsx
+++ b/components/Filter/FilterAsset.tsx
@@ -6,6 +6,7 @@ import {
   AccordionPanel,
   Button,
   Checkbox,
+  CheckboxGroup,
   Flex,
   FormControl,
   FormErrorMessage,
@@ -111,6 +112,7 @@ const FilterAsset: NextPage<Props> = ({
     skip: !!selectedCollection,
   })
 
+  console.log(filter.traits)
   const collection = useMemo(() => {
     if (selectedCollection) return selectedCollection
     if (!filterResult.collection) return null
@@ -512,36 +514,40 @@ const FilterAsset: NextPage<Props> = ({
               </Flex>
             </AccordionButton>
             <AccordionPanel maxHeight="400px" overflow="auto">
-              <Stack spacing={1}>
-                {values.map(({ value, count }, i) => (
-                  <Checkbox
-                    key={i}
-                    isChecked={filter.traits
-                      .find((x) => x.type === type)
-                      ?.values.includes(value)}
-                    onChange={(e) =>
-                      e.target.checked
-                        ? addTrait(type, value)
-                        : removeTrait(type, value)
-                    }
-                  >
-                    <Flex justifyContent="space-between" gap={3}>
-                      <Text
-                        variant="subtitle2"
-                        color="black"
-                        noOfLines={1}
-                        wordBreak="break-word"
-                        title={value}
-                      >
-                        {value}
-                      </Text>
-                      <Text variant="subtitle2" color="black">
-                        {count}
-                      </Text>
-                    </Flex>
-                  </Checkbox>
-                ))}
-              </Stack>
+              <CheckboxGroup
+                defaultValue={
+                  filter?.traits?.find((trait) => trait.type === type)?.values
+                }
+              >
+                <Stack spacing={1}>
+                  {values.map(({ value, count }, i) => (
+                    <Checkbox
+                      key={i}
+                      value={value}
+                      onChange={(e) =>
+                        e.target.checked
+                          ? addTrait(type, value)
+                          : removeTrait(type, value)
+                      }
+                    >
+                      <Flex justifyContent="space-between" gap={3}>
+                        <Text
+                          variant="subtitle2"
+                          color="black"
+                          noOfLines={1}
+                          wordBreak="break-word"
+                          title={value}
+                        >
+                          {value}
+                        </Text>
+                        <Text variant="subtitle2" color="black">
+                          {count}
+                        </Text>
+                      </Flex>
+                    </Checkbox>
+                  ))}
+                </Stack>
+              </CheckboxGroup>
             </AccordionPanel>
           </AccordionItem>
         ))}


### PR DESCRIPTION
### Project organization
- Related [trello card
](https://trello.com/c/9QnyXEto/670-unselect-the-first-trait-on-explore-page-doesnt-unselect-it)

### Description
Fixes Checkbox component to show correct checked value.

### How to test
Play with the checkbox on the explore page, you need to filter by collection to see traits and play with it. Simply choose anything you want, refresh the page, and it should always show the correct one from now on.

### Checklist
- [x] Base branch of the PR is `dev`
