### PR TITLE
Notification page link redirection improvement

### DIFF
--- a/components/Notification/Detail.tsx
+++ b/components/Notification/Detail.tsx
@@ -27,6 +27,7 @@ import {
 
 export type IProps = {
   createdAt: Date
+  currentAccount: string | null
   action: NotificationAction
   accountVerification: {
     status: AccountVerificationStatus
@@ -47,7 +48,6 @@ export type IProps = {
     unitPrice: string
     quantity: string
     asset: {
-      id: string
       image: string
       name: string
     }
@@ -73,6 +73,7 @@ export type IProps = {
 export default function NotificationDetail({
   action,
   createdAt,
+  currentAccount,
   accountVerification,
   auction,
   offer,
@@ -93,6 +94,7 @@ export default function NotificationDetail({
         userAddress: string
       }
     | undefined = useMemo(() => {
+    invariant(currentAccount, 'currentAccount is required')
     switch (action) {
       case 'ACCOUNT_VERIFICATION_VALIDATED':
         invariant(accountVerification, 'accountVerification is required')
@@ -100,38 +102,38 @@ export default function NotificationDetail({
 
       case 'OFFER_PURCHASED':
         invariant(offer, 'offer is required')
-        return OfferPurchased({ offer, trade })
+        return OfferPurchased({ currentAccount, offer, trade })
 
       case 'BID_ACCEPTED':
         invariant(offer, 'offer is required')
-        return BidAccepted({ offer })
+        return BidAccepted({ currentAccount, offer })
 
       case 'BID_CREATED':
         invariant(offer, 'offer is required')
-        return BidCreated({ offer })
+        return BidCreated({ currentAccount, offer })
 
       case 'AUCTION_BID_CREATED':
         invariant(auction, 'auction is required')
         invariant(offer, 'offer is required')
-        return AuctionBidCreated({ auction, offer })
+        return AuctionBidCreated({ auction, currentAccount, offer })
 
       case 'AUCTION_BID_EXPIRED':
         invariant(auction, 'auction is required')
         invariant(offer, 'offer is required')
-        return AuctionBidExpired({ auction, offer })
+        return AuctionBidExpired({ auction, currentAccount, offer })
 
       case 'AUCTION_ENDED_WON_SELLER':
         invariant(auction, 'auction is required')
         invariant(offer, 'offer is required')
-        return AuctionEndedWonSeller({ auction, offer })
+        return AuctionEndedWonSeller({ auction, currentAccount, offer })
 
       case 'AUCTION_ENDED_RESERVEPRICE_SELLER':
         invariant(auction, 'auction is required')
-        return AuctionEndedReservePriceSeller({ auction })
+        return AuctionEndedReservePriceSeller({ auction, currentAccount })
 
       case 'AUCTION_ENDED_NOBIDS':
         invariant(auction, 'auction is required')
-        return AuctionEndedNoBids({ auction })
+        return AuctionEndedNoBids({ auction, currentAccount })
 
       case 'AUCTION_ENDED_WON_BUYER':
         invariant(auction, 'auction is required')
@@ -144,25 +146,33 @@ export default function NotificationDetail({
       case 'AUCTION_EXPIRE_SOON':
         invariant(auction, 'auction is required')
         invariant(offer, 'offer is required')
-        return AuctionExpireSoon({ auction, offer })
+        return AuctionExpireSoon({ auction, currentAccount, offer })
 
       case 'AUCTION_EXPIRED':
         invariant(auction, 'auction is required')
-        return AuctionExpired({ auction })
+        return AuctionExpired({ auction, currentAccount })
 
       case 'BID_EXPIRED':
         invariant(offer, 'offer is required')
-        return BidExpired({ offer })
+        return BidExpired({ currentAccount, offer })
 
       case 'OFFER_EXPIRED':
         invariant(offer, 'sale is required')
-        return OfferExpired({ offer })
+        return OfferExpired({ currentAccount, offer })
 
       case 'REFERRAL_REFEREE_REGISTERED':
         invariant(refereeAccount, 'refereeAccount is required')
         return ReferralRefereeRegistered({ refereeAccount })
     }
-  }, [accountVerification, action, auction, offer, trade, refereeAccount])
+  }, [
+    currentAccount,
+    action,
+    accountVerification,
+    offer,
+    trade,
+    auction,
+    refereeAccount,
+  ])
 
   if (!content) return <></>
   return (

--- a/components/Notification/types/AuctionBidCreated.tsx
+++ b/components/Notification/types/AuctionBidCreated.tsx
@@ -5,11 +5,11 @@ import Price from '../../Price/Price'
 export type IProps = {
   auction: {
     asset: {
-      id: string
       image: string
       name: string
     }
   }
+  currentAccount: string
   offer: {
     amount: string
     currency: {
@@ -19,13 +19,17 @@ export type IProps = {
   }
 }
 
-export default function AuctionBidCreated({ auction, offer }: IProps): {
+export default function AuctionBidCreated({
+  auction,
+  currentAccount,
+  offer,
+}: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${auction.asset.id}`,
+    link: `/users/${currentAccount}/bids`,
     image: auction.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/AuctionBidExpired.tsx
+++ b/components/Notification/types/AuctionBidExpired.tsx
@@ -5,11 +5,11 @@ import Price from '../../Price/Price'
 export type IProps = {
   auction: {
     asset: {
-      id: string
       image: string
       name: string
     }
   }
+  currentAccount: string
   offer: {
     amount: string
     currency: {
@@ -19,13 +19,17 @@ export type IProps = {
   }
 }
 
-export default function AuctionBidExpired({ offer, auction }: IProps): {
+export default function AuctionBidExpired({
+  auction,
+  currentAccount,
+  offer,
+}: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${auction.asset.id}`,
+    link: `/users/${currentAccount}/bids/placed`,
     image: auction.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/AuctionEndedNoBids.tsx
+++ b/components/Notification/types/AuctionEndedNoBids.tsx
@@ -4,20 +4,23 @@ import Trans from 'next-translate/Trans'
 export type IProps = {
   auction: {
     asset: {
-      id: string
       image: string
       name: string
     }
   }
+  currentAccount: string
 }
 
-export default function AuctionEndedNoBids({ auction }: IProps): {
+export default function AuctionEndedNoBids({
+  auction,
+  currentAccount,
+}: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${auction.asset.id}`,
+    link: `/users/${currentAccount}/offers/auction`,
     image: auction.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/AuctionEndedReservePriceSeller.tsx
+++ b/components/Notification/types/AuctionEndedReservePriceSeller.tsx
@@ -4,20 +4,23 @@ import Trans from 'next-translate/Trans'
 export type IProps = {
   auction: {
     asset: {
-      id: string
       image: string
       name: string
     }
   }
+  currentAccount: string
 }
 
-export default function AuctionEndedReservePriceSeller({ auction }: IProps): {
+export default function AuctionEndedReservePriceSeller({
+  auction,
+  currentAccount,
+}: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${auction.asset.id}`,
+    link: `/users/${currentAccount}/offers/auction`,
     image: auction.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/AuctionEndedWonSeller.tsx
+++ b/components/Notification/types/AuctionEndedWonSeller.tsx
@@ -5,11 +5,11 @@ import Price from '../../Price/Price'
 export type IProps = {
   auction: {
     asset: {
-      id: string
       image: string
       name: string
     }
   }
+  currentAccount: string
   offer: {
     amount: string
     currency: {
@@ -19,13 +19,17 @@ export type IProps = {
   }
 }
 
-export default function AuctionEndedWonSeller({ auction, offer }: IProps): {
+export default function AuctionEndedWonSeller({
+  auction,
+  currentAccount,
+  offer,
+}: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${auction.asset.id}`,
+    link: `/users/${currentAccount}/offers/auction`,
     image: auction.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/AuctionExpireSoon.tsx
+++ b/components/Notification/types/AuctionExpireSoon.tsx
@@ -5,11 +5,11 @@ import Price from '../../Price/Price'
 export type IProps = {
   auction: {
     asset: {
-      id: string
       image: string
       name: string
     }
   }
+  currentAccount: string
   offer: {
     amount: string
     currency: {
@@ -19,13 +19,17 @@ export type IProps = {
   }
 }
 
-export default function AuctionExpireSoon({ auction, offer }: IProps): {
+export default function AuctionExpireSoon({
+  auction,
+  currentAccount,
+  offer,
+}: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${auction.asset.id}`,
+    link: `/users/${currentAccount}/offers/auction`,
     image: auction.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/AuctionExpired.tsx
+++ b/components/Notification/types/AuctionExpired.tsx
@@ -4,20 +4,20 @@ import Trans from 'next-translate/Trans'
 export type IProps = {
   auction: {
     asset: {
-      id: string
       image: string
       name: string
     }
   }
+  currentAccount: string
 }
 
-export default function AuctionExpired({ auction }: IProps): {
+export default function AuctionExpired({ auction, currentAccount }: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${auction.asset.id}`,
+    link: `/users/${currentAccount}/offers/auction`,
     image: auction.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/BidAccepted.tsx
+++ b/components/Notification/types/BidAccepted.tsx
@@ -3,11 +3,11 @@ import Trans from 'next-translate/Trans'
 import Price from '../../Price/Price'
 
 export type IProps = {
+  currentAccount: string
   offer: {
     unitPrice: string
     quantity: string
     asset: {
-      id: string
       image: string
       name: string
     }
@@ -18,13 +18,13 @@ export type IProps = {
   }
 }
 
-export default function BidAccepted({ offer }: IProps): {
+export default function BidAccepted({ currentAccount, offer }: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${offer.asset.id}`,
+    link: `/users/${currentAccount}/trades/purchased`,
     image: offer.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/BidCreated.tsx
+++ b/components/Notification/types/BidCreated.tsx
@@ -3,11 +3,11 @@ import Trans from 'next-translate/Trans'
 import Price from '../../Price/Price'
 
 export type IProps = {
+  currentAccount: string
   offer: {
     unitPrice: string
     quantity: string
     asset: {
-      id: string
       image: string
       name: string
     }
@@ -18,13 +18,13 @@ export type IProps = {
   }
 }
 
-export default function BidCreated({ offer }: IProps): {
+export default function BidCreated({ currentAccount, offer }: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${offer.asset.id}`,
+    link: `/users/${currentAccount}/bids`,
     image: offer.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/BidExpired.tsx
+++ b/components/Notification/types/BidExpired.tsx
@@ -3,12 +3,12 @@ import Trans from 'next-translate/Trans'
 import Price from '../../Price/Price'
 
 export type IProps = {
+  currentAccount: string
   offer: {
     amount: string
     unitPrice: string
     quantity: string
     asset: {
-      id: string
       image: string
       name: string
     }
@@ -19,13 +19,13 @@ export type IProps = {
   }
 }
 
-export default function BidExpired({ offer }: IProps): {
+export default function BidExpired({ currentAccount, offer }: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${offer.asset.id}`,
+    link: `/users/${currentAccount}/bids/placed`,
     image: offer.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/OfferExpired.tsx
+++ b/components/Notification/types/OfferExpired.tsx
@@ -2,22 +2,22 @@ import { Text } from '@chakra-ui/react'
 import Trans from 'next-translate/Trans'
 
 export type IProps = {
+  currentAccount: string
   offer: {
     asset: {
-      id: string
       image: string
       name: string
     }
   }
 }
 
-export default function OfferExpired({ offer }: IProps): {
+export default function OfferExpired({ currentAccount, offer }: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${offer.asset.id}`,
+    link: `/users/${currentAccount}/offers`,
     image: offer.asset.image,
     children: (
       <Trans

--- a/components/Notification/types/OfferPurchased.tsx
+++ b/components/Notification/types/OfferPurchased.tsx
@@ -4,6 +4,7 @@ import Trans from 'next-translate/Trans'
 import Price from '../../Price/Price'
 
 export type IProps = {
+  currentAccount: string
   offer: {
     amount: string
     unitPrice: string
@@ -12,7 +13,6 @@ export type IProps = {
       symbol: string
     }
     asset: {
-      id: string
       image: string
       name: string
     }
@@ -26,13 +26,17 @@ export type IProps = {
   } | null
 }
 
-export default function OfferPurchased({ offer, trade }: IProps): {
+export default function OfferPurchased({
+  currentAccount,
+  offer,
+  trade,
+}: IProps): {
   link: string
   image: string
   children: JSX.Element
 } {
   return {
-    link: `/tokens/${offer.asset.id}`,
+    link: `/users/${currentAccount}/trades`,
     image: offer.asset.image,
     children: trade ? (
       <Trans

--- a/pages/notification.gql
+++ b/pages/notification.gql
@@ -47,7 +47,6 @@ query GetNotifications($address: Address!, $cursor: Cursor) {
         unitPrice
         quantity
         asset {
-          id
           image
           name
         }

--- a/pages/notification.tsx
+++ b/pages/notification.tsx
@@ -101,7 +101,11 @@ const NotificationPage: NextPage<Props> = ({ currentAccount }) => {
         {(notifications || []).length > 0 ? (
           <>
             {notifications.map((notification) => (
-              <NotificationDetail key={notification.id} {...notification} />
+              <NotificationDetail
+                key={notification.id}
+                currentAccount={currentAccount}
+                {...notification}
+              />
             ))}
             {hasNextPage && (
               <Button isLoading={loading} onClick={loadMore}>


### PR DESCRIPTION
### Project organization
- Related [trello card](https://trello.com/c/beWElkHo/655-notification-link-redirection-improvement)

### Description
Adds new redirections for the items on notification page

### How to test
Test by clicking different type of notifications on the notification page. It should redirect user to the related page now instead of directing everything to the token detail page.

### Checklist
- [x] Base branch of the PR is `dev`