### PR TITLE
Implement a simpler fix of onConnect and onDisconnect

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -40,7 +40,7 @@ import { MittEmitter } from 'next/dist/shared/lib/mitt'
 import { FC, HTMLAttributes, useEffect, useRef, VFC } from 'react'
 import { useCookies } from 'react-cookie'
 import { useForm } from 'react-hook-form'
-import { useAccount as useWagmiAccount, useDisconnect } from 'wagmi'
+import { useDisconnect } from 'wagmi'
 import { useNavbarAccountQuery } from '../../graphql'
 import useAccount from '../../hooks/useAccount'
 import Image from '../Image/Image'
@@ -396,8 +396,7 @@ const Navbar: VFC<{
   multiLang?: MultiLang
 }> = ({ allowTopUp, logo, router, multiLang, disableMinting, signer }) => {
   const { t } = useTranslation('components')
-  const { isConnected } = useWagmiAccount()
-  const { address, isLoggedIn, logout } = useAccount()
+  const { address, isLoggedIn, logout, isConnected } = useAccount()
   const { disconnect } = useDisconnect()
   const { asPath, query, push, isReady } = router
   const { register, setValue, handleSubmit } = useForm<FormData>()

--- a/hooks/useAccount.ts
+++ b/hooks/useAccount.ts
@@ -24,6 +24,7 @@ const COOKIE_OPTIONS = {
 export default function useAccount(): AccountDetail {
   const { address, isConnected } = useWagmiAccount({
     // FIXME: Implements dummy onConnect and onDisconnect functions to prevent a bug only present with React 17 where other onConnect and onDisconnect in the same component (eg: AccountProvider) are not triggered if another useWagmiAccount doesn't implement those functions.
+    // See https://github.com/liteflow-labs/starter-kit/pull/230#issuecomment-1477409307 for more info.
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     onConnect: () => {},
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/hooks/useAccount.ts
+++ b/hooks/useAccount.ts
@@ -3,10 +3,11 @@ import { useAuthenticate, useIsLoggedIn } from '@nft/hooks'
 import jwtDecode, { JwtPayload } from 'jwt-decode'
 import { useCallback, useMemo } from 'react'
 import { useCookies } from 'react-cookie'
-import { Connector } from 'wagmi'
+import { Connector, useAccount as useWagmiAccount } from 'wagmi'
 
 type AccountDetail = {
   isLoggedIn: boolean
+  isConnected: boolean
   address?: string
   jwtToken: string | null
   logout: () => Promise<void>
@@ -21,9 +22,17 @@ const COOKIE_OPTIONS = {
 }
 
 export default function useAccount(): AccountDetail {
+  const { address, isConnected } = useWagmiAccount({
+    // FIXME: Implements dummy onConnect and onDisconnect functions to prevent a bug only present with React 17 where other onConnect and onDisconnect in the same component (eg: AccountProvider) are not triggered if another useWagmiAccount doesn't implement those functions.
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onConnect: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onDisconnect: () => {},
+  })
   const [authenticate, { setAuthenticationToken, resetAuthenticationToken }] =
     useAuthenticate()
   const [cookies, setCookie, removeCookie] = useCookies([COOKIE_JWT_TOKEN])
+  const isLoggedIn = useIsLoggedIn(address || '')
 
   const logout = useCallback(async () => {
     resetAuthenticationToken()
@@ -37,9 +46,6 @@ export default function useAccount(): AccountDetail {
     if (res.exp && res.exp < Math.ceil(Date.now() / 1000)) return null
     return { address: res.address.toLowerCase(), token: jwtToken }
   }, [cookies])
-
-  const address = useMemo(() => jwt?.address, [jwt])
-  const isLoggedIn = useIsLoggedIn(address || '')
 
   const login = useCallback(
     async (connector: Connector<any, any, Signer>) => {
@@ -70,6 +76,7 @@ export default function useAccount(): AccountDetail {
       address: jwt?.address?.toLowerCase(),
       jwtToken: jwt?.token,
       isLoggedIn: !!jwt,
+      isConnected: !!jwt,
       logout,
       login,
     }
@@ -79,6 +86,7 @@ export default function useAccount(): AccountDetail {
     address: isLoggedIn ? address?.toLowerCase() : undefined,
     jwtToken: isLoggedIn ? jwt?.token : null,
     isLoggedIn,
+    isConnected,
     logout,
     login,
   }

--- a/hooks/useEagerConnect.ts
+++ b/hooks/useEagerConnect.ts
@@ -3,8 +3,8 @@ import { useAccount as useWagmiAccount } from 'wagmi'
 import useAccount from './useAccount'
 
 export default function useEagerConnect(): boolean {
-  const { isReconnecting, isConnected } = useWagmiAccount()
-  const { isLoggedIn } = useAccount()
+  const { isReconnecting } = useWagmiAccount()
+  const { isLoggedIn, isConnected } = useAccount()
   const [hasBeenReady, setHasBeenReady] = useState(false)
 
   const ready = useMemo(() => {


### PR DESCRIPTION
### Project organization

- Closes <!-- add link to issue that this PR fixes if any -->
- Related <!-- add link to related issue if any -->
- Dependant on https://github.com/liteflow-labs/starter-kit/pull/230

### Description

Implement a simpler and more visible fix about the not triggered onConnect issue that will be easy to remove when updating to React 18

### How to test

- Try to login
