### PR TITLE
Add new api types

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -16,10 +16,14 @@ config:
   scalars:
     URI: 'URI'
     UUID: 'UUID'
-    Datetime: 'Date'
+    Datetime: 'Date' # FIXME: wrong type, it's actually a string
     Cursor: 'string'
     JSON: '{ [key: string]: any }'
     Uint256: 'string'
+    Int256: 'string'
     Address: 'string'
     TransactionHash: 'string'
     BigFloat: 'string'
+    # BigInt: 'string' # FIXME: this breaks the build. Need to fix the type in the codebase
+    Bytes32: 'string'
+    FullText: 'string'

--- a/type.d.ts
+++ b/type.d.ts
@@ -20,7 +20,6 @@ declare module '@pinata/ipfs-gateway-tools/dist/node' {
   }
 }
 
-type IPFS = string
 type UUID = string
 type URI = string
 


### PR DESCRIPTION
### Description

Add new API types to codegen.
- Add types `Bytes32 `, `Int256` and `FullText`
- `Datetime` is wrongly type, it should be a `string`. Changing it breaks the build. Just put a comment for now.
- `BigInt` type is missing, it should be a `string`. Adding it breaks the build. Just put a comment for now.

Also removed the not-used TS type `IPFS`

### Checklist

- [x] Base branch of the PR is `dev`
