### PR TITLE
remove extra parenthesis in users bids page

### DIFF
--- a/pages/users/[id]/bids/received.tsx
+++ b/pages/users/[id]/bids/received.tsx
@@ -359,7 +359,6 @@ const BidReceivedPage: NextPage<Props> = ({ meta, now, userAddress }) => {
           />
         </Stack>
       </UserProfileTemplate>
-      )
     </LargeLayout>
   )
 }


### PR DESCRIPTION
Remove extra parenthesis in users bids page

<img width="1377" alt="Screenshot 2023-04-03 at 12 56 57" src="https://user-images.githubusercontent.com/5823445/229424448-ecc28e2e-71c2-4c30-8ffd-981ec5e3f2e0.png">
