### PR TITLE
Replace aggregates sum availableQuantity

### DIFF
--- a/convert.ts
+++ b/convert.ts
@@ -17,7 +17,7 @@ import {
   Offer,
   OfferOpenBuy,
   OfferOpenSale,
-  OfferOpenSaleSumAggregates,
+  OfferOpenSalesConnection,
   Ownership,
   OwnershipSumAggregates,
   Trade,
@@ -94,11 +94,7 @@ export const convertAssetWithSupplies = (
         sum: Maybe<Pick<OwnershipSumAggregates, 'quantity'>>
       }>
     }
-    sales: {
-      aggregates: Maybe<{
-        sum: Maybe<Pick<OfferOpenSaleSumAggregates, 'availableQuantity'>>
-      }>
-    }
+    sales: Pick<OfferOpenSalesConnection, 'totalAvailableQuantitySum'>
     collection: Pick<Collection, 'standard' | 'mintType'>
   },
 ): ReturnType<typeof convertAsset> & {
@@ -121,9 +117,7 @@ export const convertAssetWithSupplies = (
       standard: asset.collection.standard,
       mintType: asset.collection.mintType,
     },
-    saleSupply: BigNumber.from(
-      asset.sales.aggregates?.sum?.availableQuantity || 0,
-    ),
+    saleSupply: BigNumber.from(asset.sales.totalAvailableQuantitySum),
     totalSupply: BigNumber.from(
       asset.ownerships.aggregates?.sum?.quantity || '0',
     ),

--- a/pages/index.gql
+++ b/pages/index.gql
@@ -110,11 +110,7 @@ fragment HomeAssetDetail on Asset {
         }
       }
     }
-    aggregates {
-      sum {
-        availableQuantity
-      }
-    }
+    totalAvailableQuantitySum
   }
   auctions(first: 1, orderBy: CREATED_AT_DESC) {
     nodes {

--- a/pages/tokens/[id]/index.gql
+++ b/pages/tokens/[id]/index.gql
@@ -162,11 +162,7 @@ query FetchAsset($id: String!, $address: Address, $now: Datetime!) {
           }
         }
       }
-      aggregates {
-        sum {
-          availableQuantity
-        }
-      }
+      totalAvailableQuantitySum
     }
     auctions(first: 1, orderBy: CREATED_AT_DESC) {
       nodes {

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -461,9 +461,7 @@ const DetailPage: NextPage<Props> = ({
             creator={creator}
             owners={owners}
             numberOfOwners={asset.ownerships.totalCount}
-            saleSupply={BigNumber.from(
-              asset.sales.aggregates?.sum?.availableQuantity || 0,
-            )}
+            saleSupply={BigNumber.from(asset.sales.totalAvailableQuantitySum)}
             standard={asset.collection.standard}
             totalSupply={BigNumber.from(
               asset.ownerships.aggregates?.sum?.quantity || '0',


### PR DESCRIPTION
### Project organization

- Dependant on https://github.com/liteflow-labs/backend/pull/2619

### Description

Replace the aggregates sales' sum availableQuantity by `totalAvailableQuantitySum `.
Require backend PR https://github.com/liteflow-labs/backend/pull/2619 to be released first.

In draft until backend is updated.

### Checklist

- [x] Base branch of the PR is `dev`