### PR TITLE
Replace useChainId with useNetwork from wagmi

### DIFF
--- a/components/Button/SwitchNetwork.tsx
+++ b/components/Button/SwitchNetwork.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps, useToast } from '@chakra-ui/react'
 import { formatError } from '@nft/hooks'
 import { PropsWithChildren, useCallback } from 'react'
-import { useChainId, useSwitchNetwork } from 'wagmi'
+import { useNetwork, useSwitchNetwork } from 'wagmi'
 
 const ButtonWithNetworkSwitch = ({
   children,
@@ -12,7 +12,7 @@ const ButtonWithNetworkSwitch = ({
     chainId: number
   }
 >): JSX.Element => {
-  const currentChainId = useChainId()
+  const { chain } = useNetwork()
   const { switchNetwork, isLoading } = useSwitchNetwork({
     chainId,
     throwForSwitchChainNotSupported: true,
@@ -30,7 +30,7 @@ const ButtonWithNetworkSwitch = ({
     switchNetwork()
   }, [switchNetwork])
 
-  if (currentChainId !== chainId)
+  if (chain?.id !== chainId)
     return (
       <Button
         {...props}


### PR DESCRIPTION
### Description
`useChainId` from wagmi was always returning chain id from the ones we have defined on chains.
`chain` from `useNetwork` doesn't need to be defined and always returns the correct chain Id whether that has been defined or not.

### How to test
Switch to other networks and use switch network button. It should work for all.

### Checklist
- [x] Base branch of the PR is `dev`
