### PR TITLE
Fix randomization of assets

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,6 @@ import { HiArrowNarrowRight } from '@react-icons/all-files/hi/HiArrowNarrowRight
 import { NextPage } from 'next'
 import useTranslation from 'next-translate/useTranslation'
 import { useCallback, useEffect, useMemo } from 'react'
-import invariant from 'ts-invariant'
 import Link from '../components/Link/Link'
 import Loader from '../components/Loader'
 import Slider from '../components/Slider/Slider'
@@ -54,16 +53,22 @@ const HomePage: NextPage<Props> = ({ now }) => {
     if (environment.HOME_TOKENS) {
       // Pseudo randomize the array based on the date's seconds
       const tokens = [...environment.HOME_TOKENS]
-      const rng = (date.getTime() / 1000) % tokens.length
-      for (let i = 0; i < tokens.length; i++) {
-        const j = (i + rng) % tokens.length
-        const [temp1, temp2] = [tokens[i], tokens[j]]
-        invariant(temp1)
-        invariant(temp2)
-        tokens[i] = temp2
-        tokens[j] = temp1
+
+      const seed = date.getTime() / 1000 // convert to seconds as date is currently truncated to the second
+      const randomTokens = []
+      while (
+        tokens.length &&
+        randomTokens.length < environment.PAGINATION_LIMIT
+      ) {
+        // generate random based on seed and length of the remaining tokens array
+        // It will change when seed changes (basically every request) and also on each iteration of the loop as length of tokens changes
+        const randomIndex = seed % tokens.length
+        // remove the element from tokens
+        const element = tokens.splice(randomIndex, 1)
+        // push the element into the returned array in order
+        randomTokens.push(...element)
       }
-      return tokens.slice(0, environment.PAGINATION_LIMIT)
+      return randomTokens
     }
     return (tokensToRender?.assets?.nodes || []).map((x) => x.id)
   }, [tokensToRender, date])

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,6 +12,7 @@ import { HiArrowNarrowRight } from '@react-icons/all-files/hi/HiArrowNarrowRight
 import { NextPage } from 'next'
 import useTranslation from 'next-translate/useTranslation'
 import { useCallback, useEffect, useMemo } from 'react'
+import invariant from 'ts-invariant'
 import Link from '../components/Link/Link'
 import Loader from '../components/Loader'
 import Slider from '../components/Slider/Slider'
@@ -51,13 +52,21 @@ const HomePage: NextPage<Props> = ({ now }) => {
 
   const assetIds = useMemo(() => {
     if (environment.HOME_TOKENS) {
-      return environment.HOME_TOKENS.sort(() => Math.random() - 0.5).slice(
-        0,
-        environment.PAGINATION_LIMIT,
-      )
+      // Pseudo randomize the array based on the date's seconds
+      const tokens = [...environment.HOME_TOKENS]
+      const rng = (date.getTime() / 1000) % tokens.length
+      for (let i = 0; i < tokens.length; i++) {
+        const j = (i + rng) % tokens.length
+        const [temp1, temp2] = [tokens[i], tokens[j]]
+        invariant(temp1)
+        invariant(temp2)
+        tokens[i] = temp2
+        tokens[j] = temp1
+      }
+      return tokens.slice(0, environment.PAGINATION_LIMIT)
     }
     return (tokensToRender?.assets?.nodes || []).map((x) => x.id)
-  }, [tokensToRender])
+  }, [tokensToRender, date])
 
   const { data, refetch, error, loading } = useFetchHomePageQuery({
     variables: {


### PR DESCRIPTION
### Project organization

- Closes #257 

### Description

When the home page is loading with HOME_TOKENS variable set, the server-side rendering has an infinite loop because of the use of random that returns always a different array resulting in a never-ending fetching of assets with these new random ids
