### PR TITLE
Fix invalid button type when switching network

### DIFF
--- a/components/Button/SwitchNetwork.tsx
+++ b/components/Button/SwitchNetwork.tsx
@@ -30,7 +30,7 @@ const ButtonWithNetworkSwitch = ({
     switchNetwork()
   }, [switchNetwork])
 
-  if (chain?.id !== chainId)
+  if (chain && chain.id !== chainId)
     return (
       <Button
         {...props}


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/starter-kit/issues/260

### Description

For some reason chakra has issues switching from one type of button to another one, and the switch network, when rendered in ssr did not have any chain, thus creating a button of type button, but the page was updating it as a type submit, but the html tag was not updated even tho the type is correctly set.

To limit/avoid the server now renders by default what the client expect if connected on the right chain
