### PR TITLE
Fix double referral link creation

### DIFF
--- a/components/User/Profile/Info.tsx
+++ b/components/User/Profile/Info.tsx
@@ -61,6 +61,7 @@ const UserProfileInfo: VFC<{
     if (referralUrl) return
     if (!loginUrlForReferral) return
     if (!signer) return
+    if (creatingReferralLink) return
     createReferralLink()
       .then((id) => setReferralUrl(`${loginUrlForReferral}?ref=${id}`))
       .catch((error) =>
@@ -76,6 +77,7 @@ const UserProfileInfo: VFC<{
     loginUrlForReferral,
     toast,
     signer,
+    creatingReferralLink,
   ])
 
   const handleReferralCopyLink = useCallback(() => {


### PR DESCRIPTION
### Project organization

- Closes https://github.com/liteflow-labs/starter-kit/issues/261

### Description

Because the signer is changed at the initialization (even tho the data is the same), the `useEffect` in the profile triggers twice the creation of an invitation. As this request is not idempotent (even tho we can only have one), this can trigger errors.
The system now only calls this API only if there is no request in progress.

### How to test

Create a new account an go to the profile page, and you should not have an error (while before this, you would have the error). 
