### PR TITLE
Load bids and history as separated queries

### DIFF
--- a/components/Bid/BidList.gql
+++ b/components/Bid/BidList.gql
@@ -1,0 +1,71 @@
+query FetchAssetBids($id: String!, $now: Datetime!) {
+  asset(id: $id) {
+    bids(
+      orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
+      filter: { expiredAt: { greaterThan: $now } }
+    ) {
+      nodes {
+        id
+        createdAt
+        expiredAt
+        availableQuantity
+        taker {
+          address
+        }
+        maker {
+          address
+          name
+          image
+          verification {
+            status
+          }
+        }
+        amount
+        unitPrice
+        currency {
+          image
+          name
+          id
+          decimals
+          symbol
+        }
+      }
+    }
+  }
+}
+
+query FetchAuctionBids($auctionId: UUID!, $now: Datetime!) {
+  auction(id: $auctionId) {
+    offers(
+      orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
+      filter: { signature: { isNull: false }, expiredAt: { greaterThan: $now } }
+    ) {
+      nodes {
+        id
+        createdAt
+        expiredAt
+        availableQuantity
+        taker {
+          address
+        }
+        maker {
+          address
+          name
+          image
+          verification {
+            status
+          }
+        }
+        amount
+        unitPrice
+        currency {
+          image
+          name
+          id
+          decimals
+          symbol
+        }
+      }
+    }
+  }
+}

--- a/components/Bid/BidList.tsx
+++ b/components/Bid/BidList.tsx
@@ -2,19 +2,24 @@ import { Text } from '@chakra-ui/react'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
 import useTranslation from 'next-translate/useTranslation'
-import { VFC } from 'react'
-import { BlockExplorer } from '../../hooks/useBlockExplorer'
+import { useMemo, VFC } from 'react'
+import { convertBidFull } from '../../convert'
+import { useFetchAssetBidsQuery, useFetchAuctionBidsQuery } from '../../graphql'
+import useBlockExplorer from '../../hooks/useBlockExplorer'
 import List from '../List/List'
-import type { Props as BidProps } from './Bid'
+import SkeletonList from '../Skeleton/List'
+import SkeletonListItem from '../Skeleton/ListItem'
 import Bid from './Bid'
 
 type Props = {
-  bids: (BidProps['bid'] & { currency: { id: string } })[]
+  now: Date
   chainId: number
+  collectionAddress: string
+  tokenId: string
+  auctionId: string | undefined
   signer: Signer | undefined
   account: string | null | undefined
   isSingle: boolean
-  blockExplorer: BlockExplorer
   preventAcceptation: boolean
   totalOwned: BigNumber
   onAccepted: (id: string) => Promise<void>
@@ -22,44 +27,82 @@ type Props = {
 }
 
 const BidList: VFC<Props> = ({
-  bids,
+  now,
   chainId,
+  collectionAddress,
+  tokenId,
+  auctionId,
   signer,
   account,
   isSingle,
-  blockExplorer,
   preventAcceptation,
   totalOwned,
   onAccepted,
   onCanceled,
 }) => {
   const { t } = useTranslation('components')
-  if (bids.length === 0)
-    return (
-      <Text as="p" variant="text" color="gray.500">
-        {t('bid.list.none')}
-      </Text>
-    )
+  const bidResults = useFetchAssetBidsQuery({
+    variables: {
+      id: [chainId, collectionAddress, tokenId].join('-'),
+      now: now,
+    },
+    skip: !!auctionId,
+  })
+  const auctionBidResult = useFetchAuctionBidsQuery({
+    variables: {
+      auctionId: auctionId || '',
+      now,
+    },
+    skip: !auctionId,
+  })
+  const blockExplorer = useBlockExplorer(chainId)
+
+  const result = useMemo(
+    () => (auctionId ? auctionBidResult : bidResults),
+    [auctionId, auctionBidResult, bidResults],
+  )
+
+  const bids = useMemo(() => {
+    const list = auctionId
+      ? auctionBidResult.data?.auction?.offers.nodes ||
+        auctionBidResult.previousData?.auction?.offers.nodes ||
+        []
+      : bidResults.data?.asset?.bids.nodes ||
+        bidResults.previousData?.asset?.bids.nodes ||
+        []
+    return list.map(convertBidFull)
+  }, [auctionBidResult, auctionId, bidResults])
+
   return (
     <List>
-      {bids.map((bid, i) => (
-        <>
-          {i > 0 && bids[i - 1]?.currency.id !== bid.currency.id && <hr />}
-          <Bid
-            bid={bid}
-            chainId={chainId}
-            key={bid.id}
-            signer={signer}
-            account={account}
-            preventAcceptation={preventAcceptation}
-            blockExplorer={blockExplorer}
-            onAccepted={onAccepted}
-            onCanceled={onCanceled}
-            isSingle={isSingle}
-            totalOwned={totalOwned}
-          />
-        </>
-      ))}
+      {result.loading ? (
+        <SkeletonList items={5}>
+          <SkeletonListItem image subtitle caption />
+        </SkeletonList>
+      ) : bids.length > 0 ? (
+        bids.map((bid, i) => (
+          <>
+            {i > 0 && bids[i - 1]?.currency.id !== bid.currency.id && <hr />}
+            <Bid
+              bid={bid}
+              chainId={chainId}
+              key={bid.id}
+              signer={signer}
+              account={account}
+              preventAcceptation={preventAcceptation}
+              blockExplorer={blockExplorer}
+              onAccepted={onAccepted}
+              onCanceled={onCanceled}
+              isSingle={isSingle}
+              totalOwned={totalOwned}
+            />
+          </>
+        ))
+      ) : (
+        <Text as="p" variant="text" color="gray.500">
+          {t('bid.list.none')}
+        </Text>
+      )}
     </List>
   )
 }

--- a/components/History/HistoryList.gql
+++ b/components/History/HistoryList.gql
@@ -1,0 +1,35 @@
+query FetchAssetHistory($id: String!) {
+  asset(id: $id) {
+    histories(orderBy: DATE_DESC) {
+      nodes {
+        action
+        date
+        unitPrice
+        quantity
+        fromAddress
+        from {
+          address
+          name
+          image
+          verification {
+            status
+          }
+        }
+        toAddress
+        to {
+          address
+          name
+          image
+          verification {
+            status
+          }
+        }
+        transactionHash
+        currency {
+          decimals
+          symbol
+        }
+      }
+    }
+  }
+}

--- a/components/Skeleton/List.tsx
+++ b/components/Skeleton/List.tsx
@@ -1,0 +1,18 @@
+import { FC, Fragment } from 'react'
+import List from '../List/List'
+
+type Props = {
+  items: number
+}
+
+const SkeletonList: FC<Props> = ({ items, children }) => {
+  return (
+    <List>
+      {Array.from({ length: items }).map((_, i) => (
+        <Fragment key={i}>{children}</Fragment>
+      ))}
+    </List>
+  )
+}
+
+export default SkeletonList

--- a/components/Skeleton/ListItem.tsx
+++ b/components/Skeleton/ListItem.tsx
@@ -1,0 +1,25 @@
+import { Flex, Skeleton, Stack, StackProps } from '@chakra-ui/react'
+import { FC } from 'react'
+
+type Props = StackProps & {
+  image?: boolean
+  subtitle?: boolean
+  caption?: boolean
+}
+
+const SkeletonListItem: FC<Props> = ({ caption, image, subtitle }) => {
+  return (
+    <Stack as="li" padding={2}>
+      <Flex align="center" gap={3}>
+        {image && <Skeleton h={10} w={10} borderRadius="full" />}
+        <Flex flex={1} gap={1} direction="column">
+          <Skeleton height="15px" width="250px" />
+          {subtitle && <Skeleton height="15px" width="300px" />}
+          {caption && <Skeleton height="15px" width="100px" />}
+        </Flex>
+      </Flex>
+    </Stack>
+  )
+}
+
+export default SkeletonListItem

--- a/pages/tokens/[id]/index.gql
+++ b/pages/tokens/[id]/index.gql
@@ -216,36 +216,5 @@ query FetchAsset($id: String!, $address: Address, $now: Datetime!) {
         }
       }
     }
-    histories(orderBy: DATE_DESC) {
-      nodes {
-        action
-        date
-        unitPrice
-        quantity
-        fromAddress
-        from {
-          address
-          name
-          image
-          verification {
-            status
-          }
-        }
-        toAddress
-        to {
-          address
-          name
-          image
-          verification {
-            status
-          }
-        }
-        transactionHash
-        currency {
-          decimals
-          symbol
-        }
-      }
-    }
   }
 }

--- a/pages/tokens/[id]/index.gql
+++ b/pages/tokens/[id]/index.gql
@@ -107,37 +107,6 @@ query FetchAsset($id: String!, $address: Address, $now: Datetime!) {
         }
       }
     }
-    bids(
-      orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-      filter: { expiredAt: { greaterThan: $now } }
-    ) {
-      nodes {
-        id
-        createdAt
-        expiredAt
-        availableQuantity
-        taker {
-          address
-        }
-        maker {
-          address
-          name
-          image
-          verification {
-            status
-          }
-        }
-        amount
-        unitPrice
-        currency {
-          image
-          name
-          id
-          decimals
-          symbol
-        }
-      }
-    }
     sales(
       orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
       filter: { expiredAt: { greaterThan: $now } }
@@ -186,6 +155,7 @@ query FetchAsset($id: String!, $address: Address, $now: Datetime!) {
         offers(
           orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
           filter: { signature: { isNull: false } }
+          first: 1
         ) {
           nodes {
             id

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -152,8 +152,10 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
   )
 
   const now = useNow()
-  const activeAuction = useMemo(() => {
-    const auction = asset?.auctions.nodes[0]
+  const auction = useMemo(() => {
+    const first = asset?.auctions.nodes[0]
+    if (!first) return
+    const auction = convertAuctionFull(first)
     if (!auction) return
     // check if auction is expired
     if (new Date(auction.expireAt) <= now) return
@@ -162,23 +164,8 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
     return auction
   }, [asset, now])
 
-  const bids = useMemo(() => {
-    if (!asset) return []
-    return activeAuction
-      ? activeAuction.offers.nodes.map(convertBidFull)
-      : asset.bids.nodes.length > 0
-      ? asset.bids.nodes.map(convertBidFull)
-      : []
-  }, [activeAuction, asset])
-
   const directSales = useMemo(
     () => asset?.sales.nodes.map(convertSaleFull) || [],
-    [asset],
-  )
-
-  const auction = useMemo(
-    () =>
-      asset?.auctions.nodes.map((auction) => convertAuctionFull(auction))[0],
     [asset],
   )
 
@@ -503,13 +490,15 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
           <Box h={96} overflowY="auto" py={6}>
             {(!query.filter || query.filter === AssetTabs.bids) && (
               <BidList
-                bids={bids}
+                now={date}
                 chainId={chainId}
+                collectionAddress={collectionAddress}
+                tokenId={tokenId}
+                auctionId={auction?.id}
                 signer={signer}
                 account={address}
                 isSingle={isSingle}
-                blockExplorer={blockExplorer}
-                preventAcceptation={!isOwner || !!activeAuction}
+                preventAcceptation={!isOwner || !!auction}
                 onAccepted={refresh}
                 onCanceled={refresh}
                 totalOwned={totalOwned}


### PR DESCRIPTION
In the detail page, the bids and history are now loaded as separated queries with their respective skeleton

This should improve the performance as we were always requesting both information (even tho not both were displayed)
We were also querying all open bids and all auction bids, now we only retrieve what's necessary.

