### PR TITLE
Add emails notifications for bid/auction/offer/trades

### DIFF
--- a/emails/AuctionBidCreated.ts
+++ b/emails/AuctionBidCreated.ts
@@ -15,28 +15,24 @@ export default function AuctionBidCreated({
   subject: string
   to: string
 } | null {
-  const amount = formatUnits(
-    BigNumber.from(unitPrice).mul(quantity),
-    currency.decimals,
-  )
+  const amount = BigNumber.from(unitPrice).mul(quantity)
   if (!taker?.email) return null
   return {
     to: taker.email,
-    subject: `New bid of ${amount} ${currency.symbol} received for your auction on ${asset.name}`,
-    html: `Hi <strong>${taker.username || taker.address}</strong>,
-<br/>
-<br/>
-We are pleased to let you know that you have received a new bid of <strong>${amount} ${
+    subject: `New bid of ${formatUnits(amount, currency.decimals)} ${
       currency.symbol
-    }</strong> from <strong>${
+    } received for your auction on ${asset.name}`,
+    html: `Hi <strong>${taker.username || taker.address}</strong>,<br/>
+    <br/>
+    We are pleased to let you know that you have received a new bid of <strong>${formatUnits(
+      amount,
+      currency.decimals,
+    )} ${currency.symbol}</strong> from <strong>${
       maker.username || maker.address
-    }</strong> for your auction on <strong>${asset.name}</strong>.
-<br/>
-<br/>      
-To view the bid click the link below.
-<br/>
-<br/>
-<a href="${environment.BASE_URL}/tokens/${asset.id}">View the bid</a>
-<br/>`,
+    }</strong> for your auction on <strong>${asset.name}</strong>.<br/>
+    <br/>      
+    To view the bid click the link below.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${asset.id}">View the bid</a><br/>`,
   }
 }

--- a/emails/AuctionBidExpired.ts
+++ b/emails/AuctionBidExpired.ts
@@ -1,0 +1,39 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatUnits } from '@ethersproject/units'
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+
+export default function AuctionBidExpired({
+  asset,
+  maker,
+  unitPrice,
+  currency,
+  quantity,
+}: Events['AUCTION_BID_EXPIRED']): {
+  html: string
+  subject: string
+  to: string
+} | null {
+  if (!maker?.email) return null
+  const amount = BigNumber.from(quantity).mul(unitPrice)
+  return {
+    to: maker.email,
+    subject: `Your bid of ${formatUnits(amount, currency.decimals)} ${
+      currency.symbol
+    } for the auction on ${asset.name} has met the expiration date`,
+    html: `Hi <strong>${maker.username || maker.address}</strong>,<br/>
+    <br/>
+    The auction for the NFT <strong>${
+      asset.name
+    }</strong> and your bid placed on it have met the expiration date. Your bid of <strong>${formatUnits(
+      amount,
+      currency.decimals,
+    )} ${currency.symbol}</strong> has been canceled.<br/>
+    <br/>
+    You can place an open bid for this NFT at anytime. To do so just click the link below that will redirect you to it.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Go to the NFT page</a><br/>`,
+  }
+}

--- a/emails/AuctionEndedNoBids.ts
+++ b/emails/AuctionEndedNoBids.ts
@@ -1,0 +1,39 @@
+import { formatDate } from '@nft/hooks'
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+import { fetchAdditionalAuctionData } from './auction-utils'
+
+export default async function AuctionEndedNoBids({
+  id,
+  endAt,
+  asset,
+  creator,
+}: Events['AUCTION_ENDED']): Promise<{
+  html: string
+  subject: string
+  to: string
+} | null> {
+  const { expireAt, bestOffer } = await fetchAdditionalAuctionData(id, endAt)
+
+  if (!!bestOffer) return null
+  if (!creator?.email) return null
+  return {
+    to: creator.email,
+    subject: `Your auction has ended but no bids were placed for ${asset.name}`,
+    html: `Hi <strong>${creator.username || creator.address}</strong>,<br/>
+    <br/>
+    Your auction for the NFT <strong>${
+      asset.name
+    }</strong> has ended but hasn't received any bids.<br/>
+    <br/>
+    Friendly tips, create a new sale for this NFT and share it around you to gather interest.<br/>
+    <br/>
+    Without action from your side after the <strong>${formatDate(
+      expireAt,
+    )}</strong>, the auction and its bids will be canceled.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Create a new sale</a><br/>`,
+  }
+}

--- a/emails/AuctionEndedReservePriceBuyer.ts
+++ b/emails/AuctionEndedReservePriceBuyer.ts
@@ -1,0 +1,43 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatDate } from '@nft/hooks'
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+import { fetchAdditionalAuctionData } from './auction-utils'
+
+export default async function AuctionEndedReservePriceBuyer({
+  id,
+  endAt,
+  asset,
+  reserveAmount,
+}: Events['AUCTION_ENDED']): Promise<{
+  html: string
+  subject: string
+  to: string
+} | null> {
+  const { expireAt, bestOffer } = await fetchAdditionalAuctionData(id, endAt)
+
+  if (!bestOffer) return null
+  if (BigNumber.from(bestOffer.amount).gte(reserveAmount)) return null
+  if (!bestOffer.maker?.email) return null
+  return {
+    to: bestOffer.maker.email,
+    subject: `The auction has ended but the reserve price hasn't been met for ${asset.name}`,
+    html: `Hi <strong>${
+      bestOffer.maker.username || bestOffer.maker.address
+    }</strong>,<br/>
+    <br/>
+    You recently participated in an auction for the NFT <strong>${
+      asset.name
+    }</strong> which has ended.<br/>
+    <br/>
+    Unfortunately the reserve price for this auction hasn't been met. After the <strong>${formatDate(
+      expireAt,
+    )}</strong>, the auction and the bid you placed will be canceled.<br/>
+    <br/>
+    Keep an eye on this NFT as the owner might list it for sale again!<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Go to the NFT page</a><br/>`,
+  }
+}

--- a/emails/AuctionEndedReservePriceSeller.ts
+++ b/emails/AuctionEndedReservePriceSeller.ts
@@ -1,0 +1,47 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatUnits } from '@ethersproject/units'
+import { formatDate } from '@nft/hooks'
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+import { fetchAdditionalAuctionData } from './auction-utils'
+
+export default async function AuctionEndedReservePriceSeller({
+  id,
+  endAt,
+  asset,
+  creator,
+  currency,
+  reserveAmount,
+}: Events['AUCTION_ENDED']): Promise<{
+  html: string
+  subject: string
+  to: string
+} | null> {
+  const { expireAt, bestOffer } = await fetchAdditionalAuctionData(id, endAt)
+
+  if (!bestOffer) return null
+  if (BigNumber.from(bestOffer.amount).gte(reserveAmount)) return null
+  if (!creator?.email) return null
+  return {
+    to: creator.email,
+    subject: `Your auction has ended but the reserve price hasn't been met for ${asset.name}`,
+    html: `Hi <strong>${creator.username || creator.address}</strong>,<br/>
+    <br/>
+    Your auction for the NFT <strong>${
+      asset.name
+    }</strong> has ended but the reserve price of <strong>${formatUnits(
+      reserveAmount,
+      currency.decimals,
+    )} ${currency.symbol}</strong> hasn't been met.<br/>
+    <br/>
+    Friendly tips, create a new sale for this NFT and share it around you to gather interest.<br/>
+    <br/>
+    Without action from your side after the <strong>${formatDate(
+      expireAt,
+    )}</strong>, the auction and its bids will be canceled.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Create a new sale</a><br/>`,
+  }
+}

--- a/emails/AuctionEndedWonBuyer.ts
+++ b/emails/AuctionEndedWonBuyer.ts
@@ -1,0 +1,49 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatUnits } from '@ethersproject/units'
+import { formatDate } from '@nft/hooks'
+import { Events } from '@nft/webhook'
+import { fetchAdditionalAuctionData } from './auction-utils'
+
+export default async function AuctionEndedWonBuyer({
+  id,
+  endAt,
+  asset,
+  creator,
+  currency,
+  reserveAmount,
+}: Events['AUCTION_ENDED']): Promise<{
+  html: string
+  subject: string
+  to: string
+} | null> {
+  const { expireAt, bestOffer } = await fetchAdditionalAuctionData(id, endAt)
+
+  if (!bestOffer) return null
+  if (BigNumber.from(bestOffer.amount).lt(reserveAmount)) return null
+  if (!bestOffer.maker?.email) return null
+  return {
+    to: bestOffer.maker.email,
+    subject: `You won the auction for ${asset.name}`,
+    html: `Hi <strong>${
+      bestOffer.maker.username || bestOffer.maker.address
+    }</strong>,<br/>
+    <br/>
+    We are pleased to let you know that you won the auction for the NFT <strong>${
+      asset.name
+    }</strong> for <strong>${formatUnits(
+      bestOffer.amount,
+      currency.decimals,
+    )} ${currency.symbol}</strong>.<br/>
+    <br/>
+    <strong>${
+      creator.username || creator.address
+    }</strong> has until the <strong>${formatDate(
+      expireAt,
+    )}</strong> to confirm the sale.<br/>
+    <br/>
+    Please make sure that you have <strong>${formatUnits(
+      bestOffer.amount,
+      currency.decimals,
+    )} ${currency.symbol}</strong> available in your wallet.<br/>`,
+  }
+}

--- a/emails/AuctionEndedWonSeller.ts
+++ b/emails/AuctionEndedWonSeller.ts
@@ -1,0 +1,47 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatUnits } from '@ethersproject/units'
+import { formatDate } from '@nft/hooks'
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+import { fetchAdditionalAuctionData } from './auction-utils'
+
+export default async function AuctionEndedWonSeller({
+  id,
+  asset,
+  creator,
+  currency,
+  reserveAmount,
+  endAt,
+}: Events['AUCTION_ENDED']): Promise<{
+  html: string
+  subject: string
+  to: string
+} | null> {
+  const { expireAt, bestOffer } = await fetchAdditionalAuctionData(id, endAt)
+
+  if (!bestOffer) return null
+  if (BigNumber.from(bestOffer.amount).lt(reserveAmount)) return null
+  if (!creator?.email) return null
+  return {
+    to: creator.email,
+    subject: `Your auction has been won for ${asset.name}`,
+    html: `Hi <strong>${creator.username || creator.address}</strong>,<br/>
+    <br/>
+    We are pleased to let you know that your auction for the NFT <strong>${
+      asset.name
+    }</strong> has been won by <strong>${
+      bestOffer.maker.username || bestOffer.maker.address
+    }</strong> for <strong>${formatUnits(
+      bestOffer.amount,
+      currency.decimals,
+    )} ${currency.symbol}</strong>.<br/>
+    <br/>
+    You have until the <strong>${formatDate(
+      expireAt,
+    )}</strong> to confirm the sale. After that the auction and its bids will be canceled.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Confirm the sale</a><br/>`,
+  }
+}

--- a/emails/AuctionExpired.ts
+++ b/emails/AuctionExpired.ts
@@ -1,0 +1,28 @@
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+
+export default function AuctionExpired({
+  asset,
+  creator,
+}: Events['AUCTION_EXPIRED']): {
+  html: string
+  subject: string
+  to: string
+} | null {
+  if (!creator?.email) return null
+  return {
+    to: creator.email,
+    subject: `The expiration date has been met for your auction on ${asset.name}`,
+    html: `Hi <strong>${creator.username || creator.address}</strong>,<br/>
+    <br/>
+    The expiration date has been met for <strong>${
+      asset.name
+    }</strong>. The auction and its bids have been canceled.<br/>
+    <br/>
+    You can create a new sale for this NFT at anytime.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Create a new sale</a><br/>`,
+  }
+}

--- a/emails/BidAccepted.ts
+++ b/emails/BidAccepted.ts
@@ -1,0 +1,44 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatUnits } from '@ethersproject/units'
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+
+export default function BidAccepted({
+  unitPrice,
+  currency,
+  quantity,
+  buyer,
+  seller,
+  offer: { asset, type },
+}: Events['TRADE_CREATED']): {
+  html: string
+  subject: string
+  to: string
+} | null {
+  if (type !== 'BUY') return null
+  if (!buyer?.email) return null
+  return {
+    to: buyer.email,
+    subject: `Your bid for ${quantity} edition${
+      BigNumber.from(quantity).gt(1) ? 's' : ''
+    } of ${asset.name} for ${formatUnits(unitPrice, currency.decimals)} ${
+      currency.symbol
+    }${BigNumber.from(quantity).gt(1) ? ' each' : ''} has been accepted`,
+    html: `Hi <strong>${buyer.username || buyer.address}</strong>,<br/>
+    <br/>
+    We are pleased to let you know that your bid for <strong>${quantity}</strong> edition${
+      BigNumber.from(quantity).gt(1) ? 's' : ''
+    } of the NFT <strong>${asset.name}</strong> for <strong>${formatUnits(
+      unitPrice,
+      currency.decimals,
+    )} ${currency.symbol}</strong>${
+      BigNumber.from(quantity).gt(1) ? ' each' : ''
+    } has been accepted by <strong>${
+      seller.username || seller.address
+    }</strong>.<br/>
+    <br/>      
+    The NFT ownership has been transferred. No additional actions are required on your side.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${asset.id}">View my NFT</a><br/>`,
+  }
+}

--- a/emails/BidCreated.ts
+++ b/emails/BidCreated.ts
@@ -17,36 +17,35 @@ export default function BidCreated({
   subject: string
   to: string
 } | null {
-  const price = formatUnits(unitPrice, currency.decimals)
-  const multiple = BigNumber.from(quantity).gt(1)
   if (!taker?.email) return null
   return {
     to: taker.email,
     subject: `New bid received for ${quantity} edition${
-      multiple ? 's' : ''
-    } of ${asset.name} for ${price} ${currency.symbol}${
-      multiple ? ' each' : ''
-    }`,
-    html: `Hi <strong>${taker.username || taker.address}</strong>,
-<br/>
-<br/>
-We are pleased to let you know that you have received a new bid from <strong>${
+      BigNumber.from(quantity).gt(1) ? 's' : ''
+    } of ${asset.name} for ${formatUnits(unitPrice, currency.decimals)} ${
+      currency.symbol
+    }${BigNumber.from(quantity).gt(1) ? ' each' : ''}`,
+    html: `Hi <strong>${taker.username || taker.address}</strong>,<br/>
+    <br/>
+    We are pleased to let you know that you have received a new bid from <strong>${
       maker.username || maker.address
     }</strong> for <strong>${quantity}</strong> edition${
-      multiple ? 's' : ''
-    } of your NFT <strong>${asset.name}</strong> for <strong>${price} ${
-      currency.symbol
-    }</strong>${multiple ? ' each' : ''}.
-<br/>
-<br/>
-You have until the <strong>${formatDate(
+      BigNumber.from(quantity).gt(1) ? 's' : ''
+    } of your NFT <strong>${asset.name}</strong> for <strong>${formatUnits(
+      unitPrice,
+      currency.decimals,
+    )} ${currency.symbol}</strong>${
+      BigNumber.from(quantity).gt(1) ? ' each' : ''
+    }.<br/>
+    <br/>
+    You have until the <strong>${formatDate(
       expiredAt,
-    )}</strong> to accept it. After that the bid will be expired.
-<br/>
-<br/>      
-To do so just click the link below that will redirect you to it.<br/>
-<br/>
-<a href="${environment.BASE_URL}/tokens/${asset.id}">Go to the NFT page</a>
-<br/>`,
+    )}</strong> to accept it. After that the bid will be expired.<br/>
+    <br/>      
+    To do so just click the link below that will redirect you to it.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Go to the NFT page</a><br/>`,
   }
 }

--- a/emails/BidExpired.ts
+++ b/emails/BidExpired.ts
@@ -1,0 +1,45 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatUnits } from '@ethersproject/units'
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+
+export default function BidExpired({
+  asset,
+  maker,
+  unitPrice,
+  currency,
+  quantity,
+}: Events['BID_EXPIRED']): {
+  html: string
+  subject: string
+  to: string
+} | null {
+  const amount = BigNumber.from(quantity).mul(unitPrice)
+  if (!maker?.email) return null
+  return {
+    to: maker.email,
+    subject: `Your bid for ${quantity} edition${
+      BigNumber.from(quantity).gt(1) ? 's' : ''
+    } of ${asset.name} for ${formatUnits(unitPrice, currency.decimals)} ${
+      currency.symbol
+    }${
+      BigNumber.from(quantity).gt(1) ? ' each' : ''
+    } has met the expiration date`,
+    html: `Hi <strong>${maker.username || maker.address}</strong>,<br/>
+    <br/>
+    Your bid for <strong>${quantity}</strong> edition${
+      BigNumber.from(quantity).gt(1) ? 's' : ''
+    } of the NFT <strong>${asset.name}</strong> for <strong>${formatUnits(
+      amount,
+      currency.decimals,
+    )} ${currency.symbol}</strong>${
+      BigNumber.from(quantity).gt(1) ? ' each' : ''
+    } has met the expiration date. The bid has been canceled.<br/>
+    <br/>
+    You can place a new bid for this NFT at anytime. To do so just click the link below that will redirect you to it.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Place a new bid</a><br/>`,
+  }
+}

--- a/emails/OfferExpired.ts
+++ b/emails/OfferExpired.ts
@@ -1,0 +1,28 @@
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+
+export default function OfferExpired({
+  asset,
+  maker,
+}: Events['OFFER_EXPIRED']): {
+  html: string
+  subject: string
+  to: string
+} | null {
+  if (!maker?.email) return null
+  return {
+    to: maker.email,
+    subject: `The expiration date has been met for your sale on ${asset.name}`,
+    html: `Hi <strong>${maker.username || maker.address}</strong>,<br/>
+    <br/>
+    The expiration date has been met for <strong>${
+      asset.name
+    }</strong>. The sale has been canceled.<br/>
+    <br/>
+    You can create a new sale for this NFT at anytime. To do so just click the link below that will redirect you to it.<br/>
+    <br/>
+    <a href="${environment.BASE_URL}/tokens/${
+      asset.id
+    }">Create a new sale</a><br/>`,
+  }
+}

--- a/emails/OfferPurchased.ts
+++ b/emails/OfferPurchased.ts
@@ -1,0 +1,41 @@
+import { BigNumber } from '@ethersproject/bignumber'
+import { formatUnits } from '@ethersproject/units'
+import { Events } from '@nft/webhook'
+import environment from '../environment'
+
+export default function OfferPurchased({
+  unitPrice,
+  currency,
+  quantity,
+  buyer,
+  seller,
+  offer: { asset, type },
+}: Events['TRADE_CREATED']): {
+  html: string
+  subject: string
+  to: string
+} | null {
+  if (type !== 'SALE') return null
+  if (!seller?.email) return null
+  return {
+    to: seller.email,
+    subject: `You sold ${quantity} edition${
+      BigNumber.from(quantity).gt(1) ? 's' : ''
+    } of ${asset.name}`,
+    html: `Hi <strong>${seller.username || seller.address}</strong>,<br/>
+    <br/>
+    We are pleased to let you know that you have sold <strong>${quantity}</strong> edition${
+      BigNumber.from(quantity).gt(1) ? 's' : ''
+    } of your NFT <strong>${asset.name}</strong> to <strong>${
+      buyer?.username || buyer.address
+    }</strong> for <strong>${formatUnits(unitPrice, currency.decimals)} ${
+      currency.symbol
+    }</strong>${BigNumber.from(quantity).gt(1) ? ' each' : ''}.<br/>
+    <br/>      
+    No additional actions are required on your side. The NFT ownership has been transferred and your wallet has been credited with the funds.<br/>
+    <br/>
+    <a href="${
+      environment.BASE_URL
+    }/account/wallet">Check my wallet balance</a>`,
+  }
+}

--- a/emails/auction-utils.ts
+++ b/emails/auction-utils.ts
@@ -1,0 +1,92 @@
+import request, { gql } from 'graphql-request'
+import invariant from 'ts-invariant'
+
+const query = gql`
+  query Auction($id: UUID!, $now: Datetime!) {
+    auction(id: $id) {
+      expireAt
+      offers(
+        filter: {
+          signature: { isNull: false }
+          expiredAt: { greaterThan: $now }
+          availableQuantity: { greaterThan: "0" }
+        }
+        orderBy: AMOUNT_DESC
+        first: 1
+      ) {
+        nodes {
+          amount
+          makerAddress
+          maker {
+            address
+            username
+            email
+          }
+        }
+      }
+    }
+  }
+`
+
+type Result = {
+  expireAt: Date
+  bestOffer: {
+    amount: string
+    maker: {
+      address: string
+      username?: string
+      email?: string
+    }
+  } | null
+}
+
+export const fetchAdditionalAuctionData = async (
+  auctionId: string,
+  endAt: string,
+): Promise<Result> => {
+  invariant(process.env.NEXT_PUBLIC_GRAPHQL_URL)
+  const { auction } = await request<{
+    auction: {
+      expireAt: string
+      offers: {
+        nodes: [
+          {
+            amount: string
+            makerAddress: string
+            maker?: {
+              address: string
+              username?: string
+              email?: string
+            }
+          },
+        ]
+      }
+    }
+  }>(
+    process.env.NEXT_PUBLIC_GRAPHQL_URL,
+    query,
+    {
+      id: auctionId,
+      now: new Date(endAt),
+    },
+    // TODO: fix this request as `email` cannot be fetched on the public API
+    // and because of that emails to bid creators are not sent
+    // {
+    //   Authorization: `Bearer ${process.env.LITEFLOW_ADMIN_TOKEN}`,
+    // },
+  )
+
+  const bestOffer = auction.offers.nodes[0]
+  return {
+    expireAt: new Date(auction.expireAt),
+    bestOffer: bestOffer
+      ? {
+          ...bestOffer,
+          maker: {
+            ...bestOffer.maker,
+            address: bestOffer.maker?.address || bestOffer.makerAddress,
+          },
+        }
+      : null,
+  }
+}

--- a/pages/api/notification.ts
+++ b/pages/api/notification.ts
@@ -3,7 +3,18 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import nodemailer, { SendMailOptions } from 'nodemailer'
 import invariant from 'ts-invariant'
 import AuctionBidCreated from '../../emails/AuctionBidCreated'
+import AuctionBidExpired from '../../emails/AuctionBidExpired'
+import AuctionEndedNoBids from '../../emails/AuctionEndedNoBids'
+import AuctionEndedReservePriceBuyer from '../../emails/AuctionEndedReservePriceBuyer'
+import AuctionEndedReservePriceSeller from '../../emails/AuctionEndedReservePriceSeller'
+import AuctionEndedWonBuyer from '../../emails/AuctionEndedWonBuyer'
+import AuctionEndedWonSeller from '../../emails/AuctionEndedWonSeller'
+import AuctionExpired from '../../emails/AuctionExpired'
+import BidAccepted from '../../emails/BidAccepted'
 import BidCreated from '../../emails/BidCreated'
+import BidExpired from '../../emails/BidExpired'
+import OfferExpired from '../../emails/OfferExpired'
+import OfferPurchased from '../../emails/OfferPurchased'
 
 invariant(process.env.EMAIL_HOST, 'env EMAIL_HOST is required')
 invariant(process.env.EMAIL_PORT, 'env EMAIL_PORT is required')
@@ -26,31 +37,42 @@ const transporter = nodemailer.createTransport({
 
 const emails = new Map<
   keyof Events,
-  ((data: Events[keyof Events]) => SendMailOptions | null)[]
+  ((data: any) => SendMailOptions | null | Promise<SendMailOptions | null>)[]
 >([
-  ['BID_CREATED', [(data) => BidCreated(data as Events['BID_CREATED'])]],
+  ['AUCTION_BID_CREATED', [AuctionBidCreated]],
+  ['BID_CREATED', [BidCreated]],
+  ['OFFER_CREATED', []],
+  ['BID_EXPIRED', [BidExpired]],
+  ['OFFER_EXPIRED', [OfferExpired]],
+  ['AUCTION_BID_EXPIRED', [AuctionBidExpired]],
+  ['TRADE_CREATED', [BidAccepted, OfferPurchased]],
   [
-    'AUCTION_BID_CREATED',
-    [(data) => AuctionBidCreated(data as Events['AUCTION_BID_CREATED'])],
+    'AUCTION_ENDED',
+    [
+      AuctionEndedNoBids,
+      AuctionEndedReservePriceBuyer,
+      AuctionEndedReservePriceSeller,
+      AuctionEndedWonBuyer,
+      AuctionEndedWonSeller,
+    ],
   ],
+  ['AUCTION_EXPIRED', [AuctionExpired]],
 ])
 
 export default async function notification(
   req: NextApiRequest,
   res: NextApiResponse,
 ): Promise<void> {
-  const { data, type } = await parseAndVerifyRequest<
-    'BID_CREATED' | 'AUCTION_BID_CREATED'
-  >(req, liteflowSecret)
+  const { data, type } = await parseAndVerifyRequest(req, liteflowSecret)
   const emailTemplates = emails.get(type)
   if (!emailTemplates)
     throw new Error(`Email template for event ${type} does not exist`)
-  const emailsToSend = emailTemplates
-    .map((template) => template(data))
-    .filter(Boolean)
+  const emailsToSend = await Promise.all(
+    emailTemplates.map((template) => template(data)),
+  )
 
   await Promise.all(
-    emailsToSend.map((email) =>
+    emailsToSend.filter(Boolean).map((email) =>
       transporter.sendMail({
         ...email,
         from: process.env.EMAIL_FROM,


### PR DESCRIPTION
### Description

Add the list of all emails in the platform to be connected with webhook.
Thanks to this, emails can now be fully customized by the client in terms of text, flow, or design.
A few tools can be used now to create beautiful emails like:
- https://react.email/
- https://mjml.io/
- or any email builder

### How to test

Add all the webhooks in the admin.
<img width="1102" alt="Screenshot 2023-04-30 at 23 52 10" src="https://user-images.githubusercontent.com/1783126/235365725-d69f08f3-c90b-44f5-b1a3-5c4113ca5193.png">

If tested locally, make sure that the URL is public using a tool like ngrok or localtunnel 
