### PR TITLE
Add link for traits on token detail page

### DIFF
--- a/components/Trait/TraitList.tsx
+++ b/components/Trait/TraitList.tsx
@@ -1,8 +1,11 @@
 import { Flex, SimpleGrid, Text } from '@chakra-ui/react'
+import Link from 'components/Link/Link'
 import useTranslation from 'next-translate/useTranslation'
-import { FC } from 'react'
+import { FC, useCallback } from 'react'
 
 type TraitListProps = {
+  chainId: number
+  collectionAddress: string
   traits: {
     type: string
     value: string
@@ -11,12 +14,23 @@ type TraitListProps = {
   }[]
 }
 
-const TraitList: FC<TraitListProps> = ({ traits }) => {
+const TraitList: FC<TraitListProps> = ({
+  chainId,
+  collectionAddress,
+  traits,
+}) => {
   const { t } = useTranslation('components')
+  const href = useCallback(
+    (type: string, value: string) =>
+      `/collection/${chainId}/${collectionAddress}?traits[${type}]=${value}`,
+    [chainId, collectionAddress],
+  )
   return (
     <SimpleGrid columns={{ base: 2, sm: 3 }} gap={3}>
       {traits.map((trait, i) => (
         <Flex
+          as={Link}
+          href={href(trait.type, trait.value)}
           key={i}
           flexDirection="column"
           rounded="xl"

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -488,7 +488,11 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
                     {t('asset.detail.traits')}
                   </Heading>
                   <Box borderRadius="2xl" p={3} borderWidth="1px">
-                    <TraitList traits={traits} />
+                    <TraitList
+                      chainId={chainId}
+                      collectionAddress={collectionAddress}
+                      traits={traits}
+                    />
                   </Box>
                 </Stack>
               )}


### PR DESCRIPTION
### Project organization
- Related [trello card](https://trello.com/c/b00BXytu/780-add-link-from-trait-on-token-details-to-pre-filtered-explore-page)

### Description
Add link to the traits on token detail page, so on click it redirects user to the collection detail page with the trait selected so they can see other tokens with the same trait.

### How to test
Go to detail page for any of the token and click one of the traits to go to that collection with trait filter selected.

### Checklist
- [x] Base branch of the PR is `dev`
