### PR TITLE
Explore user sort system added

### DIFF
--- a/locales/en/templates.json
+++ b/locales/en/templates.json
@@ -32,6 +32,14 @@
       "empty": {
         "title": "No Users Found",
         "description": "Update your filters to find more users."
+      },
+      "orderBy": {
+        "label": "Sort by",
+        "values": {
+          "createdAtDesc": "Date: Newest",
+          "createdAtAsc": "Date: Oldest",
+          "nameAsc": "Alphabetical"
+        }
       }
     },
     "collections": {

--- a/locales/es-mx/templates.json
+++ b/locales/es-mx/templates.json
@@ -32,6 +32,14 @@
       "empty": {
         "title": "No se encontraron usuarios",
         "description": "Actualiza tus filtros para encontrar más usuarios."
+      },
+      "orderBy": {
+        "label": "Ordenar por",
+        "values": {
+          "createdAtDesc": "Fecha: más recientes",
+          "createdAtAsc": "Fecha: más antiguos",
+          "nameAsc": "Alfabética"
+        }
       }
     },
     "collections": {

--- a/locales/ja/templates.json
+++ b/locales/ja/templates.json
@@ -32,6 +32,14 @@
       "empty": {
         "title": "ユーザーが見つかりません",
         "description": "フィルターを更新して、より多くのユーザーを見つけてください。"
+      },
+      "orderBy": {
+        "label": "並び替え",
+        "values": {
+          "createdAtDesc": "日付: 最も新しい",
+          "createdAtAsc": "日付: 最も古い",
+          "nameAsc": "アルファベット順"
+        }
       }
     },
     "collections": {

--- a/locales/zh-cn/templates.json
+++ b/locales/zh-cn/templates.json
@@ -32,6 +32,14 @@
       "empty": {
         "title": "未找到用户",
         "description": "请更新筛选条件来查找更多用户。"
+      },
+      "orderBy": {
+        "label": "排序方式",
+        "values": {
+          "createdAtDesc": "日期：最新",
+          "createdAtAsc": "日期：最早",
+          "nameAsc": "按字母顺序"
+        }
       }
     },
     "collections": {

--- a/pages/explore/users.gql
+++ b/pages/explore/users.gql
@@ -1,9 +1,15 @@
 query FetchExploreUsers(
   $limit: Int!
   $offset: Int!
+  $orderBy: [AccountsOrderBy!]
   $filter: [AccountFilter!]
 ) {
-  users: accounts(first: $limit, offset: $offset, filter: { and: $filter }) {
+  users: accounts(
+    first: $limit
+    offset: $offset
+    orderBy: $orderBy
+    filter: { isImported: { equalTo: false }, and: $filter }
+  ) {
     nodes {
       username
       address

--- a/pages/explore/users.tsx
+++ b/pages/explore/users.tsx
@@ -1,19 +1,32 @@
-import { Box, Flex, SimpleGrid, Text } from '@chakra-ui/react'
+import {
+  Box,
+  Flex,
+  SimpleGrid,
+  Text,
+  useBreakpointValue,
+} from '@chakra-ui/react'
 import { NextPage } from 'next'
 import Trans from 'next-translate/Trans'
 import useTranslation from 'next-translate/useTranslation'
-import { useMemo } from 'react'
+import { useRouter } from 'next/router'
+import { useCallback, useMemo } from 'react'
 import Empty from '../../components/Empty/Empty'
 import ExploreTemplate from '../../components/Explore'
 import Head from '../../components/Head'
 import Pagination from '../../components/Pagination/Pagination'
+import Select from '../../components/Select/Select'
 import SkeletonGrid from '../../components/Skeleton/Grid'
 import SkeletonUserCard from '../../components/Skeleton/UserCard'
 import UserCard from '../../components/User/UserCard'
 import { convertUserWithCover } from '../../convert'
 import environment from '../../environment'
-import { AccountFilter, useFetchExploreUsersQuery } from '../../graphql'
+import {
+  AccountFilter,
+  AccountsOrderBy,
+  useFetchExploreUsersQuery,
+} from '../../graphql'
 import useEagerConnect from '../../hooks/useEagerConnect'
+import useOrderByQuery from '../../hooks/useOrderByQuery'
 import usePaginate from '../../hooks/usePaginate'
 import usePaginateQuery from '../../hooks/usePaginateQuery'
 import useQueryParamSingle from '../../hooks/useQueryParamSingle'
@@ -31,16 +44,31 @@ const searchFilter = (search: string): AccountFilter =>
 
 const UsersPage: NextPage<Props> = () => {
   useEagerConnect()
+  const { query, pathname, push } = useRouter()
+  const isSmall = useBreakpointValue({ base: true, md: false })
   const { t } = useTranslation('templates')
+  const orderBy = useOrderByQuery<AccountsOrderBy>('CREATED_AT_DESC')
   const { limit, offset, page } = usePaginateQuery()
   const search = useQueryParamSingle('search')
   const { data, loading } = useFetchExploreUsersQuery({
     variables: {
       limit,
       offset,
+      orderBy,
       filter: search ? searchFilter(search) : [],
     },
   })
+
+  const changeOrder = useCallback(
+    async (orderBy: any) => {
+      await push(
+        { pathname, query: { ...query, orderBy, page: undefined } },
+        undefined,
+        { shallow: true },
+      )
+    },
+    [push, pathname, query],
+  )
 
   const [changePage, changeLimit] = usePaginate()
 
@@ -56,6 +84,31 @@ const UsersPage: NextPage<Props> = () => {
         selectedTabIndex={2}
       >
         <>
+          <Flex pt={6} justifyContent="flex-end">
+            <Box>
+              <Select<AccountsOrderBy>
+                label={isSmall ? undefined : t('explore.users.orderBy.label')}
+                name="orderBy"
+                onChange={changeOrder}
+                choices={[
+                  {
+                    label: t('explore.users.orderBy.values.createdAtDesc'),
+                    value: 'CREATED_AT_DESC',
+                  },
+                  {
+                    label: t('explore.users.orderBy.values.createdAtAsc'),
+                    value: 'CREATED_AT_ASC',
+                  },
+                  {
+                    label: t('explore.users.orderBy.values.nameAsc'),
+                    value: 'NAME_ASC',
+                  },
+                ]}
+                value={orderBy}
+                inlineLabel
+              />
+            </Box>
+          </Flex>
           {loading ? (
             <SkeletonGrid items={environment.PAGINATION_LIMIT} compact py={6}>
               <SkeletonUserCard />


### PR DESCRIPTION
### Project organization
- Related [trello card](https://trello.com/c/Av38FGsO/807-explore-user-sort-system)

### Description
Hide imported accounts from the explore page and add sorting system, where you can filter by creation date (asc, desc) and alphabetical order.

### How to test
Go to explore page users tab and use the new sort select.

### Checklist
- [x] Base branch of the PR is `dev`
