### PR TITLE
Remove the default zero value from the profile page tabs

### DIFF
--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -41,10 +41,10 @@ const UserProfileTemplate: FC<{
   )
   const totals = useMemo(
     () =>
-      new Map<TabsEnum, number>([
-        ['created', metadata?.created?.totalCount || 0],
-        ['on-sale', metadata?.onSale?.totalCount || 0],
-        ['owned', metadata?.owned?.totalCount || 0],
+      new Map<TabsEnum, number | undefined>([
+        ['created', metadata?.created?.totalCount],
+        ['on-sale', metadata?.onSale?.totalCount],
+        ['owned', metadata?.owned?.totalCount],
       ]),
     [metadata],
   )

--- a/components/User/Profile/Navigation.tsx
+++ b/components/User/Profile/Navigation.tsx
@@ -15,7 +15,7 @@ export type IProps = {
   baseUrl: string
   showPrivateTabs: boolean
   currentTab: TabsEnum
-  totals: Map<TabsEnum, number>
+  totals: Map<TabsEnum, number | undefined>
 }
 
 type Tab = {

--- a/components/User/Profile/Navigation.tsx
+++ b/components/User/Profile/Navigation.tsx
@@ -36,19 +36,19 @@ const UserProfileNavigation: VFC<IProps> = ({
     () => [
       {
         title: t('user.navigation.on-sale'),
-        count: totals.get('on-sale') || 0,
+        count: totals.get('on-sale'),
         type: 'on-sale',
         href: `${baseUrl}/on-sale`,
       } as Tab,
       {
         title: t('user.navigation.owned'),
-        count: totals.get('owned') || 0,
+        count: totals.get('owned'),
         type: 'owned',
         href: `${baseUrl}/owned`,
       } as Tab,
       {
         title: t('user.navigation.created'),
-        count: totals.get('created') || 0,
+        count: totals.get('created'),
         type: 'created',
         href: `${baseUrl}/created`,
       } as Tab,


### PR DESCRIPTION
### Description

Remove the default zero value from the profile page tabs.
It was display the tag with `0` when the data is loading. Now it doesn't display the tag until the data are loaded.

### How to test

<!-- A concise explanation how to test this PR with links -->

### Checklist

- [x] Base branch of the PR is `dev`
