### PR TITLE
Media link update for ipfs

### DIFF
--- a/locales/en/templates.json
+++ b/locales/en/templates.json
@@ -107,11 +107,6 @@
         },
         "refresh-metadata": "Refresh Metadata"
       },
-      "explorerLink": "View on {{name}}",
-      "ipfsLink": "View on IPFS",
-      "errors": {
-        "image": "An issue occured"
-      },
       "details": {
         "title": "Details",
         "chain": "Chain",

--- a/locales/es-mx/templates.json
+++ b/locales/es-mx/templates.json
@@ -107,11 +107,6 @@
         },
         "refresh-metadata": "Actualizar metadatos"
       },
-      "explorerLink": "Ver en {{name}}",
-      "ipfsLink": "Ver en IPFS",
-      "errors": {
-        "image": "Ocurrió un problema"
-      },
       "details": {
         "title": "Detalles",
         "chain": "Cadena",

--- a/locales/ja/templates.json
+++ b/locales/ja/templates.json
@@ -107,11 +107,6 @@
         },
         "refresh-metadata": "メタデータの更新"
       },
-      "explorerLink": "{{name}} で表示",
-      "ipfsLink": "IPFSで表示",
-      "errors": {
-        "image": "問題が発生しました"
-      },
       "details": {
         "title": "詳細",
         "chain": "鎖",

--- a/locales/zh-cn/templates.json
+++ b/locales/zh-cn/templates.json
@@ -107,11 +107,6 @@
         },
         "refresh-metadata": "刷新元数据"
       },
-      "explorerLink": "在 {{name}} 上查看",
-      "ipfsLink": "在 IPFS 上查看",
-      "errors": {
-        "image": "出现问题"
-      },
       "details": {
         "title": "细节",
         "chain": "链",

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -453,7 +453,11 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
                     <Text variant="text-sm" color="gray.500" mr={2}>
                       {t('asset.detail.details.media')}
                     </Text>
-                    <Link href={asset.image} isExternal externalIcon>
+                    <Link
+                      href={asset.animationUrl || asset.image}
+                      isExternal
+                      externalIcon
+                    >
                       <Text variant="subtitle2">IPFS</Text>
                     </Link>
                   </Flex>


### PR DESCRIPTION
### Project organization
- Closes https://github.com/liteflow-labs/starter-kit/issues/78
- Related [trello card](https://trello.com/c/xdeqzEZf/813-media-link-for-mp4)

### Description
Adds animation url to the link and replaces image as fallback
Also removes some of the old translation files that have been used in this area.

### How to test
Click on the `View media` button on the NFT details page, and it should redirect to the correct media type now.

### Checklist
- [x] Base branch of the PR is `dev`
