### PR TITLE
Cache apollo missing query fix

### DIFF
--- a/components/HomeSection/Assets.gql
+++ b/components/HomeSection/Assets.gql
@@ -6,6 +6,9 @@ query FetchDefaultAssetIds($limit: Int!) {
   ) {
     nodes {
       id
+      chainId
+      collectionAddress
+      tokenId
     }
   }
 }


### PR DESCRIPTION
### Description
Homepage assets section was throwing cache error, added the missing query to fix the issue.

### Checklist
- [x] Base branch of the PR is `dev`
