### PR TITLE
Disable unused top up option

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -28,8 +28,6 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react'
-import { Signer } from '@ethersproject/abstract-signer'
-import { useAddFund } from '@nft/hooks'
 import { useConnectModal } from '@rainbow-me/rainbowkit'
 import { FaBell } from '@react-icons/all-files/fa/FaBell'
 import { FaEnvelope } from '@react-icons/all-files/fa/FaEnvelope'
@@ -103,22 +101,9 @@ const DrawerMenu: VFC<{
     events: MittEmitter<'routeChangeStart'>
   }
   multiLang?: MultiLang
-  topUp: {
-    allowTopUp: boolean
-    addFund: () => Promise<void>
-    addingFund: boolean
-  }
   disableMinting?: boolean
   signOutFn: () => void
-}> = ({
-  account,
-  signOutFn,
-  logo,
-  router,
-  multiLang,
-  topUp,
-  disableMinting,
-}) => {
+}> = ({ account, signOutFn, logo, router, multiLang, disableMinting }) => {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { asPath, events, query, push } = router
   const { t } = useTranslation('components')
@@ -250,16 +235,6 @@ const DrawerMenu: VFC<{
                       <Link href={`/account/edit`}>
                         <NavItemMobile>{t('navbar.user.edit')}</NavItemMobile>
                       </Link>
-                      {topUp.allowTopUp && (
-                        <NavItemMobile
-                          onClick={
-                            topUp.addingFund ? undefined : () => topUp.addFund()
-                          }
-                          as="span"
-                        >
-                          {t('navbar.user.top-up')}
-                        </NavItemMobile>
-                      )}
                       <NavItemMobile onClick={signOutFn}>
                         {t('navbar.user.sign-out')}
                       </NavItemMobile>
@@ -332,13 +307,8 @@ const UserMenu: VFC<{
     address: string
     image: string | null
   }
-  topUp: {
-    allowTopUp: boolean
-    addFund: () => Promise<void>
-    addingFund: boolean
-  }
   signOutFn: () => void
-}> = ({ account, user, topUp, signOutFn }) => {
+}> = ({ account, user, signOutFn }) => {
   const { t } = useTranslation('components')
   return (
     <Menu>
@@ -363,14 +333,6 @@ const UserMenu: VFC<{
         <Link href="/account/edit">
           <MenuItem>{t('navbar.user.edit')}</MenuItem>
         </Link>
-        {topUp.allowTopUp && (
-          <MenuItem
-            isDisabled={topUp.addingFund}
-            onClick={() => topUp.addFund()}
-          >
-            {t('navbar.user.top-up')}
-          </MenuItem>
-        )}
         <MenuItem onClick={signOutFn}>{t('navbar.user.sign-out')}</MenuItem>
       </MenuList>
     </Menu>
@@ -382,7 +344,6 @@ type FormData = {
 }
 
 const Navbar: VFC<{
-  allowTopUp: boolean
   disableMinting?: boolean
   logo?: {
     path: string
@@ -396,15 +357,13 @@ const Navbar: VFC<{
     isReady: boolean
     events: MittEmitter<'routeChangeStart'>
   }
-  signer: Signer | undefined
   multiLang?: MultiLang
-}> = ({ allowTopUp, logo, router, multiLang, disableMinting, signer }) => {
+}> = ({ logo, router, multiLang, disableMinting }) => {
   const { t } = useTranslation('components')
   const { address, isLoggedIn, logout, isConnected } = useAccount()
   const { disconnect } = useDisconnect()
   const { asPath, query, push, isReady } = router
   const { register, setValue, handleSubmit } = useForm<FormData>()
-  const [addFund, { loading: addingFund }] = useAddFund(signer)
   const [cookies] = useCookies()
   const { openConnectModal } = useConnectModal()
   const lastNotification = cookies[`lastNotification-${address}`]
@@ -534,7 +493,6 @@ const Navbar: VFC<{
               </Link>
               <UserMenu
                 account={account.address}
-                topUp={{ allowTopUp, addFund, addingFund }}
                 user={account}
                 signOutFn={() => logout().then(disconnect)}
               />
@@ -571,7 +529,6 @@ const Navbar: VFC<{
             logo={logo}
             router={router}
             multiLang={multiLang}
-            topUp={{ allowTopUp, addFund, addingFund }}
             disableMinting={disableMinting}
             signOutFn={() => logout().then(disconnect)}
           />

--- a/components/Offer/Form/Bid.tsx
+++ b/components/Offer/Form/Bid.tsx
@@ -71,7 +71,6 @@ type Props = {
   auctionId: string | undefined
   auctionValidity: number
   offerValidity: number
-  allowTopUp: boolean
 } & (
   | {
       multiple: true
@@ -97,7 +96,6 @@ const OfferFormBid: FC<Props> = (props) => {
     auctionId,
     auctionValidity,
     offerValidity,
-    allowTopUp,
   } = props
   const [createOffer, { activeStep, transactionHash }] = useCreateOffer(signer)
   const toast = useToast()
@@ -176,11 +174,6 @@ const OfferFormBid: FC<Props> = (props) => {
   const totalPrice = useMemo(() => {
     return priceUnit.mul(quantityBN)
   }, [priceUnit, quantityBN])
-
-  const balanceZero = useMemo(() => {
-    if (!balance) return false
-    return balance.isZero()
-  }, [balance])
 
   const totalFees = useMemo(() => {
     if (!totalPrice) return BigNumber.from(0)
@@ -421,12 +414,7 @@ const OfferFormBid: FC<Props> = (props) => {
 
       {account ? (
         <>
-          <Balance
-            signer={signer}
-            account={account}
-            currency={currency}
-            allowTopUp={allowTopUp && ((price && !canBid) || balanceZero)}
-          />
+          <Balance account={account} currency={currency} />
           <ButtonWithNetworkSwitch
             chainId={chainId}
             isDisabled={!canBid}

--- a/components/Offer/Form/Checkout.tsx
+++ b/components/Offer/Form/Checkout.tsx
@@ -51,7 +51,6 @@ type Props = {
   }
   onPurchased: () => void
   multiple?: boolean
-  allowTopUp: boolean
 }
 
 const OfferFormCheckout: FC<Props> = ({
@@ -63,7 +62,6 @@ const OfferFormCheckout: FC<Props> = ({
   offer,
   chainId,
   blockExplorer,
-  allowTopUp,
 }) => {
   const { t } = useTranslation('components')
   const [acceptOffer, { activeStep, transactionHash }] = useAcceptOffer(signer)
@@ -189,16 +187,7 @@ const OfferFormCheckout: FC<Props> = ({
       {/* There seems to be a rendering issue when signed in, account fetched and
       page is refreshed that will cause the <Alert /> component below to render weirdly.
       Wrapping the conditional with a div solves the issue */}
-      <div>
-        {account && (
-          <Balance
-            signer={signer}
-            account={account}
-            currency={currency}
-            allowTopUp={allowTopUp && !canPurchase}
-          />
-        )}
-      </div>
+      <div>{account && <Balance account={account} currency={currency} />}</div>
 
       <Alert status="info" borderRadius="xl" mb={8}>
         <AlertIcon />

--- a/components/User/Balance.tsx
+++ b/components/User/Balance.tsx
@@ -1,39 +1,22 @@
-import { Button, Flex, Heading, Icon, Text, VStack } from '@chakra-ui/react'
-import { Signer } from '@ethersproject/abstract-signer'
-import { useAddFund, useBalance } from '@nft/hooks'
+import { Flex, Heading, Icon, Text, VStack } from '@chakra-ui/react'
+import { useBalance } from '@nft/hooks'
 import { IoWalletOutline } from '@react-icons/all-files/io5/IoWalletOutline'
 import useTranslation from 'next-translate/useTranslation'
-import { FC, HTMLAttributes, SyntheticEvent, useCallback } from 'react'
+import { FC, HTMLAttributes } from 'react'
 import Price from '../Price/Price'
 
 const Balance: FC<
   HTMLAttributes<any> & {
-    signer: Signer | undefined
     account: string | null | undefined
     currency: {
       id: string
       decimals: number
       symbol: string
     }
-    allowTopUp?: boolean
   }
-> = ({ signer, account, currency, allowTopUp }) => {
+> = ({ account, currency }) => {
   const { t } = useTranslation('components')
-  const [balance, { loading: balanceLoading }] = useBalance(
-    account,
-    currency?.id,
-  )
-  const [addFund, { loading: addingFunds }] = useAddFund(signer)
-
-  const handleAddFund = useCallback(
-    async (e: SyntheticEvent) => {
-      e.stopPropagation()
-      e.preventDefault()
-      if (!signer) return
-      void addFund()
-    },
-    [signer, addFund],
-  )
+  const [balance] = useBalance(account, currency?.id)
 
   return (
     <VStack align="flex-start" spacing={4} mb={6}>
@@ -61,13 +44,6 @@ const Balance: FC<
           </Heading>
         )}
       </Flex>
-      {allowTopUp && !balanceLoading && (
-        <Button isLoading={addingFunds} onClick={(e) => handleAddFund(e)}>
-          <Text as="span" isTruncated>
-            {t('user.balance.add-funds')}
-          </Text>
-        </Button>
-      )}
     </VStack>
   )
 }

--- a/environment.ts
+++ b/environment.ts
@@ -22,8 +22,6 @@ type Environment = {
   RESTRICT_TO_VERIFIED_ACCOUNT: boolean
   // Limit the maximum percentage for royalties
   MAX_ROYALTIES: number
-  // Allow users to top up their wallet with fiat
-  ALLOW_TOP_UP: boolean
   // Collections where user can mint
   MINTABLE_COLLECTIONS: {
     chainId: number
@@ -112,7 +110,6 @@ const environment: Environment = {
   REFERRAL_PERCENTAGE: { base: 20 * 0.025, secondary: 20 * 0.01 },
   RESTRICT_TO_VERIFIED_ACCOUNT: true,
   MAX_ROYALTIES: 30,
-  ALLOW_TOP_UP: true,
   MINTABLE_COLLECTIONS,
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -33,7 +33,6 @@ import Navbar from '../components/Navbar/Navbar'
 import { chains, client } from '../connectors'
 import environment from '../environment'
 import useAccount, { COOKIES, COOKIE_JWT_TOKEN } from '../hooks/useAccount'
-import useSigner from '../hooks/useSigner'
 import { theme } from '../styles/theme'
 require('dayjs/locale/ja')
 require('dayjs/locale/zh-cn')
@@ -43,7 +42,6 @@ NProgress.configure({ showSpinner: false })
 
 function Layout({ children }: PropsWithChildren<{}>) {
   const router = useRouter()
-  const signer = useSigner()
   const { address } = useAccount()
   const userProfileLink = useMemo(
     () => (address ? `/users/${address}` : '/login'),
@@ -108,7 +106,6 @@ function Layout({ children }: PropsWithChildren<{}>) {
     <Box mt={12}>
       <Banner />
       <Navbar
-        allowTopUp={environment.ALLOW_TOP_UP}
         router={{
           asPath: router.asPath,
           isReady: router.isReady,
@@ -126,7 +123,6 @@ function Layout({ children }: PropsWithChildren<{}>) {
             { label: 'Spanish', value: 'es-mx' },
           ],
         }}
-        signer={signer}
         disableMinting={environment.MINTABLE_COLLECTIONS.length === 0}
       />
       {children}

--- a/pages/checkout/[id].tsx
+++ b/pages/checkout/[id].tsx
@@ -29,7 +29,6 @@ import {
   convertSale,
   convertUser,
 } from '../../convert'
-import environment from '../../environment'
 import { useCheckoutQuery, useFetchAssetForCheckoutQuery } from '../../graphql'
 import useAccount from '../../hooks/useAccount'
 import useBlockExplorer from '../../hooks/useBlockExplorer'
@@ -220,7 +219,6 @@ const CheckoutPage: NextPage<Props> = ({ now }) => {
                 currency={offer.currency}
                 multiple={!isSingle}
                 onPurchased={onPurchased}
-                allowTopUp={environment.ALLOW_TOP_UP}
               />
             )}
           </Flex>

--- a/pages/tokens/[id]/bid.tsx
+++ b/pages/tokens/[id]/bid.tsx
@@ -220,7 +220,6 @@ const BidPage: NextPage<Props> = ({ now }) => {
                 auctionId={auction?.id}
                 auctionValidity={environment.AUCTION_VALIDITY_IN_SECONDS}
                 offerValidity={environment.OFFER_VALIDITY_IN_SECONDS}
-                allowTopUp={environment.ALLOW_TOP_UP}
               />
             ) : (
               <OfferFormBid
@@ -237,7 +236,6 @@ const BidPage: NextPage<Props> = ({ now }) => {
                 auctionId={auction?.id}
                 auctionValidity={environment.AUCTION_VALIDITY_IN_SECONDS}
                 offerValidity={environment.OFFER_VALIDITY_IN_SECONDS}
-                allowTopUp={environment.ALLOW_TOP_UP}
               />
             )}
           </Flex>


### PR DESCRIPTION
Remove the option to top up your account with fiat, this is an option that has never been used and that needs to manually be removed by everyone using the starter kit.