### PR TITLE
Fix skip logic in component HomeSection Collections and Users

### DIFF
--- a/components/HomeSection/Collections.tsx
+++ b/components/HomeSection/Collections.tsx
@@ -32,7 +32,7 @@ const CollectionsHomeSection: FC<Props> = () => {
       } as CollectionFilter,
       limit: environment.PAGINATION_LIMIT,
     },
-    skip: !environment.HOME_COLLECTIONS,
+    skip: !environment.HOME_COLLECTIONS.length,
   })
   useHandleQueryError(collectionsQuery)
 

--- a/components/HomeSection/Users.tsx
+++ b/components/HomeSection/Users.tsx
@@ -17,7 +17,7 @@ const UsersHomeSection: FC<Props> = () => {
       userIds: environment.HOME_USERS || '',
       limit: environment.PAGINATION_LIMIT,
     },
-    skip: !environment.HOME_USERS,
+    skip: !environment.HOME_USERS.length,
   })
   useHandleQueryError(usersQuery)
 


### PR DESCRIPTION
### Description

I notice that the homepage on hodooi.com is executing the query `FetchCollectionsQuery` without any collections and took 1min to load because the database is busy.
The `skip` logic was not implemented correctly. An empty or filled array is always truly.

### Checklist

- [x] Base branch of the PR is `dev`
