### PR TITLE
add origin header in Apollo client

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -20,7 +20,10 @@ export default function getClient(
     uri: `${
       process.env.NEXT_PUBLIC_LITEFLOW_BASE_URL || 'https://api.liteflow.com'
     }/${environment.LITEFLOW_API_KEY}/graphql`,
-    headers: authorization ? { authorization: `Bearer ${authorization}` } : {},
+    headers: {
+      ...(authorization ? { authorization: `Bearer ${authorization}` } : {}),
+      origin: environment.BASE_URL,
+    },
     cache: new InMemoryCache({
       typePolicies: {
         Account: {


### PR DESCRIPTION
### Project organization

- Closes <!-- add link to issue that this PR fixes if any -->
- Related <!-- add link to related issue if any -->
- Dependant on <!-- add link to dependant PR if any -->

### Description

I notice the SSR GraphQL queries didn't contain an origin header, so I added it in Apollo client.

This header's value is actually replaced when running client-side.

### Checklist

- [x] Base branch of the PR is `dev`
