### PR TITLE
Prevent refetch queries after SSR

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -43,6 +43,7 @@ export default function getClient(
         fetchPolicy: 'cache-and-network',
       },
     },
+    ssrForceFetchDelay: 100,
   })
   return _client
 }


### PR DESCRIPTION
### Description

Prevent refetch queries after SSR by using the option `ssrForceFetchDelay`.
https://www.apollographql.com/docs/react/performance/server-side-rendering/#overriding-fetch-policies-during-initialization

On homepage, before:
<img width="925" alt="Screenshot 2023-06-30 at 17 42 20" src="https://github.com/liteflow-labs/starter-kit/assets/5823445/fed072c8-905e-4b8b-996e-35e0c852757a">
After:
<img width="925" alt="Screenshot 2023-06-30 at 17 43 16" src="https://github.com/liteflow-labs/starter-kit/assets/5823445/65741efe-b524-4d2e-b06e-e406509303c7">


### Checklist

- [x] Base branch of the PR is `dev`