### PR TITLE
Disallow `/api/` in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Crawl-Delay: 10
 Disallow: /_next/image
+Disallow: /api/


### PR DESCRIPTION
### Description

Disallow `/api/` in robots.txt

### Checklist

- [x] Base branch of the PR is `dev`
