### PR TITLE
Fallback to default explorer if etherscan is not set for the chain

### DIFF
--- a/hooks/useBlockExplorer.ts
+++ b/hooks/useBlockExplorer.ts
@@ -9,11 +9,9 @@ export type BlockExplorer = {
 }
 
 export function blockExplorer(chainId: number | undefined): BlockExplorer {
-  const explorer = chainId
-    ? chains.find((chain) => chain.id === chainId)?.blockExplorers?.[
-        'etherscan'
-      ]
-    : null
+  const chain = chains.find((chain) => chain.id === chainId)
+  const explorer =
+    chain?.blockExplorers?.['etherscan'] || chain?.blockExplorers?.default
 
   return {
     name: explorer?.name || '',


### PR DESCRIPTION
### Description

Fallback to default explorer if Etherscan is not set for the chain.
Links might not work but at least we send the users to the explorer.

### Checklist

- [x] Base branch of the PR is `dev`