### PR TITLE
remove fallback to 0 in useBalance and WalletBalance

### DIFF
--- a/components/Wallet/Account/WalletBalance.tsx
+++ b/components/Wallet/Account/WalletBalance.tsx
@@ -22,7 +22,8 @@ const WalletBalance: FC<{
         speed="0.65s"
       />
     )
-  return <Price amount={balance || 0} currency={currency} />
+  if (!balance) return '-'
+  return <Price amount={balance} currency={currency} />
 }
 
 export default WalletBalance

--- a/hooks/useBalance.ts
+++ b/hooks/useBalance.ts
@@ -5,7 +5,7 @@ import { useBalance as useWagmiBalance } from 'wagmi'
 export default function useBalance(
   account: string | null | undefined,
   currencyId: string | null | undefined,
-): [BigNumber, { loading: boolean }] {
+): [BigNumber | undefined, { loading: boolean }] {
   const [chainId, address] = (currencyId || '').split('-')
   const { data: balance, isLoading } = useWagmiBalance({
     enabled: !!currencyId && !!account,
@@ -14,7 +14,7 @@ export default function useBalance(
     token: address ? toAddress(address) : undefined,
   })
   return [
-    balance ? BigNumber.from(balance.value) : BigNumber.from(0),
+    balance ? BigNumber.from(balance.value) : undefined,
     { loading: isLoading },
   ]
 }


### PR DESCRIPTION
### Description

Remove fallback to `0` in `useBalance` and `WalletBalance`. Now it display `-` if the balance was not properly loaded.

Before:
<img width="734" alt="Screenshot 2023-07-27 at 15 04 02" src="https://github.com/liteflow-labs/starter-kit/assets/5823445/eb928554-bbce-44ce-a199-eaab3620a260">


After:
<img width="734" alt="Screenshot 2023-07-27 at 15 03 28" src="https://github.com/liteflow-labs/starter-kit/assets/5823445/4e371377-cd6d-461e-a1bb-5e0d210f5b27">


### Checklist

- [x] Base branch of the PR is `dev`
- [ ] Update docs if necessary <!-- Docs in https://github.com/liteflow-labs/liteflow-js/tree/main/docs/pages/starter-kit -->
