### PR TITLE
Add limit of 100 to asset histories query

### DIFF
--- a/components/History/HistoryList.gql
+++ b/components/History/HistoryList.gql
@@ -11,7 +11,7 @@ query FetchAssetHistory(
     chainId
     collectionAddress
     tokenId
-    histories(orderBy: DATE_DESC) {
+    histories(orderBy: DATE_DESC, first: 100) {
       nodes {
         action
         date


### PR DESCRIPTION
### Description

Add a limit of 100 histories query

### Checklist

- [x] Base branch of the PR is `dev`