### PR TITLE
Collection header query split

### DIFF
--- a/components/Collection/CollectionHeader.tsx
+++ b/components/Collection/CollectionHeader.tsx
@@ -17,38 +17,35 @@ import { FaGlobe } from '@react-icons/all-files/fa/FaGlobe'
 import { FaTwitter } from '@react-icons/all-files/fa/FaTwitter'
 import { HiBadgeCheck } from '@react-icons/all-files/hi/HiBadgeCheck'
 import { HiOutlineDotsHorizontal } from '@react-icons/all-files/hi/HiOutlineDotsHorizontal'
-import Etherscan from 'components/Icons/Etherscan'
-import Image from 'components/Image/Image'
-import Link from 'components/Link/Link'
-import Truncate from 'components/Truncate/Truncate'
 import useBlockExplorer from 'hooks/useBlockExplorer'
 import useTranslation from 'next-translate/useTranslation'
 import numbro from 'numbro'
 import { FC, useMemo } from 'react'
-import ChakraLink from '../../components/Link/Link'
+import Etherscan from '../../components/Icons/Etherscan'
+import Image from '../../components/Image/Image'
+import Link from '../../components/Link/Link'
+import Truncate from '../../components/Truncate/Truncate'
 import { chains } from '../../connectors'
 import { formatAddress } from '../../utils'
 
 type Props = {
-  collection:
-    | {
-        address: string
-        chainId: number
-        name: string
-        description: string | null
-        image: string | null
-        cover: string | null
-        twitter: string | null
-        discord: string | null
-        website: string | null
-        deployer: {
-          address: string
-          name: string | null
-          username: string | null
-          verified: boolean
-        }
-      }
-    | undefined
+  collection: {
+    address: string
+    chainId: number
+    name: string
+    description: string | null
+    image: string | null
+    cover: string | null
+    twitter: string | null
+    discord: string | null
+    website: string | null
+    deployer: {
+      address: string
+      name: string | null
+      username: string | null
+      verified: boolean
+    }
+  }
   metrics:
     | {
         totalVolume: string
@@ -64,10 +61,10 @@ type Props = {
 
 const CollectionHeader: FC<Props> = ({ collection, metrics, reportEmail }) => {
   const { t } = useTranslation('templates')
-  const blockExplorer = useBlockExplorer(collection?.chainId)
+  const blockExplorer = useBlockExplorer(collection.chainId)
 
   const blocks = useMemo(() => {
-    const chain = chains.find((x) => x.id === collection?.chainId)
+    const chain = chains.find((x) => x.id === collection.chainId)
     return [
       metrics
         ? {
@@ -138,7 +135,7 @@ const CollectionHeader: FC<Props> = ({ collection, metrics, reportEmail }) => {
         rounded={{ base: 'none', sm: '2xl' }}
         bg="gray.200"
       >
-        {collection?.cover && (
+        {collection.cover && (
           <Image
             src={collection.cover}
             alt={collection.name}
@@ -162,7 +159,7 @@ const CollectionHeader: FC<Props> = ({ collection, metrics, reportEmail }) => {
           borderColor="white"
           bg="gray.200"
         >
-          {collection && collection.image && (
+          {collection.image && (
             <Image
               src={collection.image}
               alt={collection.name}
@@ -182,108 +179,102 @@ const CollectionHeader: FC<Props> = ({ collection, metrics, reportEmail }) => {
       >
         <Box order={{ base: 1, sm: 0 }}>
           <Heading variant="title" pb={1}>
-            {!collection ? (
-              <Skeleton height="1em" width="200px" as="span" />
-            ) : (
-              collection.name
-            )}
+            {collection.name}
           </Heading>
           <Heading color="gray.500" variant="heading1">
             {t('collection.header.by')}{' '}
             <Text
               as={Link}
-              href={`/users/${collection?.deployer.address}`}
+              href={`/users/${collection.deployer.address}`}
               color="brand.black"
             >
               <Text as="span" color="">
                 {collection?.deployer.name ||
-                  formatAddress(collection?.deployer.address, 10)}
+                  formatAddress(collection.deployer.address, 10)}
               </Text>
-              {collection?.deployer.verified && (
+              {collection.deployer.verified && (
                 <Icon as={HiBadgeCheck} color="brand.500" boxSize={5} />
               )}
             </Text>
           </Heading>
         </Box>
-        {collection && (
-          <Flex
-            justify="flex-end"
-            alignSelf={{ base: 'flex-end', sm: 'normal' }}
-            order={{ base: 0, sm: 1 }}
-          >
-            <Flex gap={4}>
+        <Flex
+          justify="flex-end"
+          alignSelf={{ base: 'flex-end', sm: 'normal' }}
+          order={{ base: 0, sm: 1 }}
+        >
+          <Flex gap={4}>
+            <IconButton
+              as={Link}
+              aria-label={`Visit ${blockExplorer.name}`}
+              icon={<Etherscan boxSize={5} />}
+              rounded="full"
+              variant="outline"
+              colorScheme="gray"
+              href={blockExplorer.address(collection.address)}
+              isExternal
+            />
+            {collection.website && (
               <IconButton
                 as={Link}
-                aria-label={`Visit ${blockExplorer.name}`}
-                icon={<Etherscan boxSize={5} />}
+                aria-label="Visit Website"
+                icon={<FaGlobe />}
                 rounded="full"
                 variant="outline"
                 colorScheme="gray"
-                href={blockExplorer.address(collection.address)}
+                href={collection.website}
                 isExternal
               />
-              {collection.website && (
-                <IconButton
-                  as={Link}
-                  aria-label="Visit Website"
-                  icon={<FaGlobe />}
-                  rounded="full"
-                  variant="outline"
-                  colorScheme="gray"
-                  href={collection.website}
-                  isExternal
-                />
-              )}
-              {collection.discord && (
-                <IconButton
-                  as={Link}
-                  aria-label="Visit Discord"
-                  icon={<FaDiscord />}
-                  rounded="full"
-                  variant="outline"
-                  colorScheme="gray"
-                  href={collection.discord}
-                  isExternal
-                />
-              )}
-              {collection.twitter && (
-                <IconButton
-                  as={Link}
-                  aria-label="Visit Twitter"
-                  icon={<FaTwitter />}
-                  rounded="full"
-                  variant="outline"
-                  colorScheme="gray"
-                  href={collection.twitter}
-                  isExternal
-                />
-              )}
-            </Flex>
-            <Divider orientation="vertical" h="40px" mx={4} />
-            <Menu autoSelect={false}>
-              <MenuButton
-                as={IconButton}
+            )}
+            {collection.discord && (
+              <IconButton
+                as={Link}
+                aria-label="Visit Discord"
+                icon={<FaDiscord />}
+                rounded="full"
                 variant="outline"
                 colorScheme="gray"
-                rounded="full"
-                aria-label="activator"
-                icon={<Icon as={HiOutlineDotsHorizontal} w={5} h={5} />}
+                href={collection.discord}
+                isExternal
               />
-              <MenuList>
-                <ChakraLink
-                  href={`mailto:${reportEmail}?subject=${encodeURI(
-                    'Report a collection',
-                  )}&body=${encodeURI(
-                    `I would like to report the following collection "${collection.name}" (#${collection.address})\nReason: `,
-                  )}`}
-                  isExternal
-                >
-                  <MenuItem>{t('collection.header.menu.report')}</MenuItem>
-                </ChakraLink>
-              </MenuList>
-            </Menu>
+            )}
+            {collection.twitter && (
+              <IconButton
+                as={Link}
+                aria-label="Visit Twitter"
+                icon={<FaTwitter />}
+                rounded="full"
+                variant="outline"
+                colorScheme="gray"
+                href={collection.twitter}
+                isExternal
+              />
+            )}
           </Flex>
-        )}
+          <Divider orientation="vertical" h="40px" mx={4} />
+          <Menu autoSelect={false}>
+            <MenuButton
+              as={IconButton}
+              variant="outline"
+              colorScheme="gray"
+              rounded="full"
+              aria-label="activator"
+              icon={<Icon as={HiOutlineDotsHorizontal} w={5} h={5} />}
+            />
+            <MenuList>
+              <Link
+                href={`mailto:${reportEmail}?subject=${encodeURI(
+                  'Report a collection',
+                )}&body=${encodeURI(
+                  `I would like to report the following collection "${collection.name}" (#${collection.address})\nReason: `,
+                )}`}
+                isExternal
+              >
+                <MenuItem>{t('collection.header.menu.report')}</MenuItem>
+              </Link>
+            </MenuList>
+          </Menu>
+        </Flex>
       </Flex>
       {collection?.description && (
         <Box mt={4}>

--- a/components/Collection/CollectionHeader.tsx
+++ b/components/Collection/CollectionHeader.tsx
@@ -9,7 +9,6 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
-  Skeleton,
   Text,
 } from '@chakra-ui/react'
 import { FaDiscord } from '@react-icons/all-files/fa/FaDiscord'
@@ -19,13 +18,11 @@ import { HiBadgeCheck } from '@react-icons/all-files/hi/HiBadgeCheck'
 import { HiOutlineDotsHorizontal } from '@react-icons/all-files/hi/HiOutlineDotsHorizontal'
 import useBlockExplorer from 'hooks/useBlockExplorer'
 import useTranslation from 'next-translate/useTranslation'
-import numbro from 'numbro'
-import { FC, useMemo } from 'react'
+import { FC } from 'react'
 import Etherscan from '../../components/Icons/Etherscan'
 import Image from '../../components/Image/Image'
 import Link from '../../components/Link/Link'
 import Truncate from '../../components/Truncate/Truncate'
-import { chains } from '../../connectors'
 import { formatAddress } from '../../utils'
 
 type Props = {
@@ -46,86 +43,12 @@ type Props = {
       verified: boolean
     }
   }
-  metrics:
-    | {
-        totalVolume: string
-        totalVolumeCurrencySymbol: string
-        floorPrice: string | null
-        floorPriceCurrencySymbol: string | null
-        totalOwners: number
-        supply: number
-      }
-    | undefined
   reportEmail: string
 }
 
-const CollectionHeader: FC<Props> = ({ collection, metrics, reportEmail }) => {
+const CollectionHeader: FC<Props> = ({ collection, reportEmail }) => {
   const { t } = useTranslation('templates')
   const blockExplorer = useBlockExplorer(collection.chainId)
-
-  const blocks = useMemo(() => {
-    const chain = chains.find((x) => x.id === collection.chainId)
-    return [
-      metrics
-        ? {
-            name: t('collection.header.data-labels.total-volume'),
-            value:
-              numbro(metrics.totalVolume).format({
-                thousandSeparated: true,
-                trimMantissa: true,
-                mantissa: 4,
-              }) +
-              ' ' +
-              metrics.totalVolumeCurrencySymbol,
-            title: `${metrics.totalVolume} ${metrics.totalVolumeCurrencySymbol}`,
-          }
-        : undefined,
-      metrics
-        ? {
-            name: t('collection.header.data-labels.floor-price'),
-            value: metrics.floorPrice
-              ? numbro(metrics.floorPrice).format({
-                  thousandSeparated: true,
-                  trimMantissa: true,
-                  mantissa: 4,
-                }) +
-                ' ' +
-                metrics.floorPriceCurrencySymbol
-              : '-',
-            title: `${metrics.floorPrice || '-'} ${
-              metrics.floorPriceCurrencySymbol
-            }`,
-          }
-        : undefined,
-      metrics
-        ? {
-            name: t('collection.header.data-labels.owners'),
-            value: numbro(metrics.totalOwners).format({
-              thousandSeparated: true,
-            }),
-            title: metrics.totalOwners?.toString(),
-          }
-        : undefined,
-      metrics
-        ? {
-            name: t('collection.header.data-labels.items'),
-            value: numbro(metrics.supply).format({ thousandSeparated: true }),
-            title: metrics.supply?.toString(),
-          }
-        : undefined,
-      {
-        type: 'separator',
-      },
-      chain
-        ? {
-            name: t('collection.header.data-labels.chain'),
-            value: chain.name,
-            title: chain.name,
-          }
-        : undefined,
-    ]
-  }, [metrics, collection, t])
-
   return (
     <>
       <Flex
@@ -283,41 +206,6 @@ const CollectionHeader: FC<Props> = ({ collection, metrics, reportEmail }) => {
           </Truncate>
         </Box>
       )}
-      <Flex alignItems="center" rowGap={2} columnGap={8} mt={4} flexWrap="wrap">
-        {blocks.map((block, i) =>
-          block?.type === 'separator' ? (
-            <Divider orientation="vertical" height="40px" key={i} />
-          ) : (
-            <Flex key={i} flexDirection="column" justifyContent="center" py={2}>
-              {!block ? (
-                <>
-                  <Skeleton height="1em" width="100px" mb={2} />
-                  <Skeleton height="1em" width="50px" />
-                </>
-              ) : (
-                <>
-                  <Text
-                    variant="button1"
-                    title={block.title}
-                    color="brand.black"
-                    isTruncated
-                  >
-                    {block.value}
-                  </Text>
-                  <Text
-                    variant="subtitle2"
-                    title={block?.name}
-                    isTruncated
-                    color="gray.500"
-                  >
-                    {block?.name}
-                  </Text>
-                </>
-              )}
-            </Flex>
-          ),
-        )}
-      </Flex>
     </>
   )
 }

--- a/components/Collection/CollectionHeaderSkeleton.tsx
+++ b/components/Collection/CollectionHeaderSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex, Skeleton, SkeletonText } from '@chakra-ui/react'
+import { Box, Skeleton, SkeletonText } from '@chakra-ui/react'
 import { FC } from 'react'
 
 const CollectionHeaderSkeleton: FC = () => {
@@ -30,29 +30,6 @@ const CollectionHeaderSkeleton: FC = () => {
         width="200px"
         mt={4}
       />
-      <Flex alignItems="center" rowGap={2} columnGap={8} mt={4} flexWrap="wrap">
-        <Flex flexDirection="column" justifyContent="center" py={2}>
-          <Skeleton height="1em" width="100px" mb={2} />
-          <Skeleton height="1em" width="50px" />
-        </Flex>
-        <Flex flexDirection="column" justifyContent="center" py={2}>
-          <Skeleton height="1em" width="100px" mb={2} />
-          <Skeleton height="1em" width="50px" />
-        </Flex>
-        <Flex flexDirection="column" justifyContent="center" py={2}>
-          <Skeleton height="1em" width="100px" mb={2} />
-          <Skeleton height="1em" width="50px" />
-        </Flex>
-        <Flex flexDirection="column" justifyContent="center" py={2}>
-          <Skeleton height="1em" width="100px" mb={2} />
-          <Skeleton height="1em" width="50px" />
-        </Flex>
-        <Divider orientation="vertical" height="40px" />
-        <Flex flexDirection="column" justifyContent="center" py={2}>
-          <Skeleton height="1em" width="100px" mb={2} />
-          <Skeleton height="1em" width="50px" />
-        </Flex>
-      </Flex>
     </>
   )
 }

--- a/components/Collection/CollectionHeaderSkeleton.tsx
+++ b/components/Collection/CollectionHeaderSkeleton.tsx
@@ -1,0 +1,60 @@
+import { Box, Divider, Flex, Skeleton, SkeletonText } from '@chakra-ui/react'
+import { FC } from 'react'
+
+const CollectionHeaderSkeleton: FC = () => {
+  return (
+    <>
+      <Box position="relative" h={200} w="full">
+        <Skeleton w="full" h="full" rounded={{ base: 'none', sm: '2xl' }} />
+        <Skeleton
+          position="absolute"
+          bottom={-16}
+          left={4}
+          w={32}
+          h={32}
+          rounded="2xl"
+          zIndex={1}
+        />
+      </Box>
+      <SkeletonText
+        noOfLines={1}
+        height="2.25em"
+        skeletonHeight="1em"
+        width="200px"
+        mt={24}
+      />
+      <SkeletonText
+        noOfLines={1}
+        height="1.75em"
+        skeletonHeight="0.875em"
+        width="200px"
+        mt={4}
+      />
+      <Flex alignItems="center" rowGap={2} columnGap={8} mt={4} flexWrap="wrap">
+        <Flex flexDirection="column" justifyContent="center" py={2}>
+          <Skeleton height="1em" width="100px" mb={2} />
+          <Skeleton height="1em" width="50px" />
+        </Flex>
+        <Flex flexDirection="column" justifyContent="center" py={2}>
+          <Skeleton height="1em" width="100px" mb={2} />
+          <Skeleton height="1em" width="50px" />
+        </Flex>
+        <Flex flexDirection="column" justifyContent="center" py={2}>
+          <Skeleton height="1em" width="100px" mb={2} />
+          <Skeleton height="1em" width="50px" />
+        </Flex>
+        <Flex flexDirection="column" justifyContent="center" py={2}>
+          <Skeleton height="1em" width="100px" mb={2} />
+          <Skeleton height="1em" width="50px" />
+        </Flex>
+        <Divider orientation="vertical" height="40px" />
+        <Flex flexDirection="column" justifyContent="center" py={2}>
+          <Skeleton height="1em" width="100px" mb={2} />
+          <Skeleton height="1em" width="50px" />
+        </Flex>
+      </Flex>
+    </>
+  )
+}
+
+export default CollectionHeaderSkeleton

--- a/components/Collection/CollectionMetrics.tsx
+++ b/components/Collection/CollectionMetrics.tsx
@@ -1,0 +1,105 @@
+import { Divider, Flex, Text } from '@chakra-ui/react'
+import useTranslation from 'next-translate/useTranslation'
+import numbro from 'numbro'
+import { FC, useMemo } from 'react'
+import { chains } from '../../connectors'
+
+type Props = {
+  chainId: number
+  metrics: {
+    totalVolume: string
+    totalVolumeCurrencySymbol: string
+    floorPrice: string | null
+    floorPriceCurrencySymbol: string | null
+    totalOwners: number
+    supply: number
+  }
+}
+
+const CollectionMetrics: FC<Props> = ({ chainId, metrics }) => {
+  const { t } = useTranslation('templates')
+
+  const blocks = useMemo(() => {
+    const chain = chains.find((x) => x.id === chainId)
+    return [
+      {
+        name: t('collection.header.data-labels.total-volume'),
+        value:
+          numbro(metrics.totalVolume).format({
+            thousandSeparated: true,
+            trimMantissa: true,
+            mantissa: 4,
+          }) +
+          ' ' +
+          metrics.totalVolumeCurrencySymbol,
+        title: `${metrics.totalVolume} ${metrics.totalVolumeCurrencySymbol}`,
+      },
+      {
+        name: t('collection.header.data-labels.floor-price'),
+        value: metrics.floorPrice
+          ? numbro(metrics.floorPrice).format({
+              thousandSeparated: true,
+              trimMantissa: true,
+              mantissa: 4,
+            }) +
+            ' ' +
+            metrics.floorPriceCurrencySymbol
+          : '-',
+        title: `${metrics.floorPrice || '-'} ${
+          metrics.floorPriceCurrencySymbol
+        }`,
+      },
+      {
+        name: t('collection.header.data-labels.owners'),
+        value: numbro(metrics.totalOwners).format({
+          thousandSeparated: true,
+        }),
+        title: metrics.totalOwners?.toString(),
+      },
+      {
+        name: t('collection.header.data-labels.items'),
+        value: numbro(metrics.supply).format({ thousandSeparated: true }),
+        title: metrics.supply?.toString(),
+      },
+      {
+        type: 'separator',
+      },
+      {
+        name: t('collection.header.data-labels.chain'),
+        value: chain?.name || '-',
+        title: chain?.name || '-',
+      },
+    ]
+  }, [chainId, metrics, t])
+
+  return (
+    <Flex alignItems="center" rowGap={2} columnGap={8} mt={4} flexWrap="wrap">
+      {blocks.map((block, i) =>
+        block.type === 'separator' ? (
+          <Divider orientation="vertical" height="40px" key={i} />
+        ) : (
+          <Flex key={i} flexDirection="column" justifyContent="center" py={2}>
+            <Text
+              variant="button1"
+              title={block.title}
+              color="brand.black"
+              isTruncated
+            >
+              {block.value}
+            </Text>
+            <Text
+              variant="subtitle2"
+              title={block?.name}
+              isTruncated
+              color="gray.500"
+            >
+              {block.name}
+            </Text>
+          </Flex>
+        ),
+      )}
+    </Flex>
+  )
+}
+
+export default CollectionMetrics

--- a/components/Collection/CollectionMetricsSkeleton.tsx
+++ b/components/Collection/CollectionMetricsSkeleton.tsx
@@ -1,0 +1,24 @@
+import { Divider, Flex, Skeleton } from '@chakra-ui/react'
+import { FC } from 'react'
+
+const CollectionMetricsSkeletonItem = () => (
+  <Flex flexDirection="column" justifyContent="center" py={2}>
+    <Skeleton height="1em" width="100px" mb={2} />
+    <Skeleton height="1em" width="50px" />
+  </Flex>
+)
+
+const CollectionMetricsSkeleton: FC = () => {
+  return (
+    <Flex alignItems="center" rowGap={2} columnGap={8} mt={4} flexWrap="wrap">
+      <CollectionMetricsSkeletonItem />
+      <CollectionMetricsSkeletonItem />
+      <CollectionMetricsSkeletonItem />
+      <CollectionMetricsSkeletonItem />
+      <Divider orientation="vertical" height="40px" />
+      <CollectionMetricsSkeletonItem />
+    </Flex>
+  )
+}
+
+export default CollectionMetricsSkeleton

--- a/convert.ts
+++ b/convert.ts
@@ -215,17 +215,10 @@ export const convertCollectionFull = (
     | 'twitter'
     | 'discord'
     | 'website'
-    | 'deployerAddress'
-    | 'numberOfOwners'
-    | 'supply'
-  > & { floorPrice: Maybe<Pick<CollectionStats, 'valueInRef' | 'refCode'>> } & {
-    totalVolume: Pick<CollectionStats, 'valueInRef' | 'refCode'>
-  } & {
-    deployer: Maybe<
-      Pick<Account, 'address' | 'name' | 'username'> & {
-        verification: Maybe<Pick<AccountVerification, 'status'>>
-      }
-    >
+  > & {
+    deployer: Pick<Account, 'address' | 'name' | 'username'> & {
+      verification: Maybe<Pick<AccountVerification, 'status'>>
+    }
   },
 ): {
   address: string
@@ -237,19 +230,12 @@ export const convertCollectionFull = (
   twitter: string | null
   discord: string | null
   website: string | null
-  deployerAddress: string
   deployer: {
     address: string
     name: string | null
     username: string | null
     verified: boolean
-  } | null
-  totalVolume: string
-  totalVolumeCurrencySymbol: string
-  floorPrice: string | null
-  floorPriceCurrencySymbol: string | null
-  totalOwners: number
-  supply: number
+  }
 } => {
   return {
     address: collection.address,
@@ -261,16 +247,31 @@ export const convertCollectionFull = (
     twitter: collection.twitter,
     discord: collection.discord,
     website: collection.website,
-    deployerAddress: collection.deployerAddress,
-    deployer: collection.deployer
-      ? {
-          address: collection.deployer.address,
-          name: collection.deployer.name,
-          username: collection.deployer.username,
-          verified: collection.deployer?.verification?.status === 'VALIDATED',
-        }
-      : null,
-    totalVolume: collection.totalVolume?.valueInRef,
+    deployer: {
+      address: collection.deployer.address,
+      name: collection.deployer.name,
+      username: collection.deployer.username,
+      verified: collection.deployer?.verification?.status === 'VALIDATED',
+    },
+  }
+}
+
+export const convertCollectionMetrics = (
+  collection: Pick<Collection, 'numberOfOwners' | 'supply'> & {
+    floorPrice: Maybe<Pick<CollectionStats, 'valueInRef' | 'refCode'>>
+  } & {
+    totalVolume: Pick<CollectionStats, 'valueInRef' | 'refCode'>
+  },
+): {
+  totalVolume: string
+  totalVolumeCurrencySymbol: string
+  floorPrice: string | null
+  floorPriceCurrencySymbol: string | null
+  totalOwners: number
+  supply: number
+} => {
+  return {
+    totalVolume: collection.totalVolume.valueInRef,
     totalVolumeCurrencySymbol: collection.totalVolume.refCode,
     floorPrice: collection.floorPrice?.valueInRef || null,
     floorPriceCurrencySymbol: collection.floorPrice?.refCode || null,

--- a/pages/collection/[chainId]/[id].gql
+++ b/pages/collection/[chainId]/[id].gql
@@ -19,6 +19,13 @@ query FetchCollectionDetails($collectionAddress: Address!, $chainId: Int!) {
         status
       }
     }
+  }
+}
+
+query FetchCollectionMetrics($collectionAddress: Address!, $chainId: Int!) {
+  collection(address: $collectionAddress, chainId: $chainId) {
+    address
+    chainId
     numberOfOwners
     supply
     floorPrice {

--- a/pages/collection/[chainId]/[id].tsx
+++ b/pages/collection/[chainId]/[id].tsx
@@ -18,6 +18,8 @@ import { useRouter } from 'next/router'
 import { FC, useCallback, useMemo } from 'react'
 import CollectionHeader from '../../../components/Collection/CollectionHeader'
 import CollectionHeaderSkeleton from '../../../components/Collection/CollectionHeaderSkeleton'
+import CollectionMetrics from '../../../components/Collection/CollectionMetrics'
+import CollectionMetricsSkeleton from '../../../components/Collection/CollectionMetricsSkeleton'
 import Empty from '../../../components/Empty/Empty'
 import FilterAsset, { NoFilter } from '../../../components/Filter/FilterAsset'
 import FilterNav from '../../../components/Filter/FilterNav'
@@ -171,9 +173,14 @@ const CollectionPage: FC<Props> = ({ now }) => {
       ) : (
         <CollectionHeader
           collection={collectionDetails}
-          metrics={collectionMetrics}
           reportEmail={environment.REPORT_EMAIL}
         />
+      )}
+
+      {!collectionMetrics ? (
+        <CollectionMetricsSkeleton />
+      ) : (
+        <CollectionMetrics chainId={chainId} metrics={collectionMetrics} />
       )}
 
       <Flex py="6" justifyContent="space-between">

--- a/pages/collection/[chainId]/[id].tsx
+++ b/pages/collection/[chainId]/[id].tsx
@@ -30,6 +30,7 @@ import {
   convertAsset,
   convertAuctionWithBestBid,
   convertCollectionFull,
+  convertCollectionMetrics,
   convertSale,
   convertUser,
 } from '../../../convert'
@@ -38,6 +39,7 @@ import {
   AssetsOrderBy,
   useFetchCollectionAssetsQuery,
   useFetchCollectionDetailsQuery,
+  useFetchCollectionMetricsQuery,
 } from '../../../graphql'
 import useAccount from '../../../hooks/useAccount'
 import useAssetFilterFromQuery, {
@@ -71,10 +73,18 @@ const CollectionPage: FC<Props> = ({ now }) => {
   const { address } = useAccount()
   const { data: collectionData } = useFetchCollectionDetailsQuery({
     variables: {
-      collectionAddress: collectionAddress,
-      chainId: chainId,
+      collectionAddress,
+      chainId,
     },
   })
+
+  const { data: collectionMetricsData } = useFetchCollectionMetricsQuery({
+    variables: {
+      collectionAddress,
+      chainId,
+    },
+  })
+
   const { limit, offset, page } = usePaginateQuery()
   const orderBy = useOrderByQuery<AssetsOrderBy>(
     'SALES_MIN_UNIT_PRICE_IN_REF_ASC',
@@ -129,6 +139,13 @@ const CollectionPage: FC<Props> = ({ now }) => {
   )
 
   const assets = assetData?.assets?.nodes
+  const collectionMetrics = useMemo(
+    () =>
+      collectionMetricsData?.collection
+        ? convertCollectionMetrics(collectionMetricsData.collection)
+        : undefined,
+    [collectionMetricsData],
+  )
 
   const changeOrder = useCallback(
     async (orderBy: any) => {
@@ -149,8 +166,8 @@ const CollectionPage: FC<Props> = ({ now }) => {
       <Head title="Explore collection" />
 
       <CollectionHeader
-        collection={collectionDetails || {}} // TODO: update collectionHeader
-        loading={!collectionDetails}
+        collection={collectionDetails}
+        metrics={collectionMetrics}
         reportEmail={environment.REPORT_EMAIL}
       />
 

--- a/pages/collection/[chainId]/[id].tsx
+++ b/pages/collection/[chainId]/[id].tsx
@@ -17,6 +17,7 @@ import Error from 'next/error'
 import { useRouter } from 'next/router'
 import { FC, useCallback, useMemo } from 'react'
 import CollectionHeader from '../../../components/Collection/CollectionHeader'
+import CollectionHeaderSkeleton from '../../../components/Collection/CollectionHeaderSkeleton'
 import Empty from '../../../components/Empty/Empty'
 import FilterAsset, { NoFilter } from '../../../components/Filter/FilterAsset'
 import FilterNav from '../../../components/Filter/FilterNav'
@@ -165,11 +166,15 @@ const CollectionPage: FC<Props> = ({ now }) => {
     <LargeLayout>
       <Head title="Explore collection" />
 
-      <CollectionHeader
-        collection={collectionDetails}
-        metrics={collectionMetrics}
-        reportEmail={environment.REPORT_EMAIL}
-      />
+      {!collectionDetails ? (
+        <CollectionHeaderSkeleton />
+      ) : (
+        <CollectionHeader
+          collection={collectionDetails}
+          metrics={collectionMetrics}
+          reportEmail={environment.REPORT_EMAIL}
+        />
+      )}
 
       <Flex py="6" justifyContent="space-between">
         <FilterNav


### PR DESCRIPTION
### Project organization
- Related [trello card](https://trello.com/b/33afSjTr/product-backlog)
- Dependant on #371 

### Description
Splits collection detail page metrics from the actual page load, so page will be accessible before the metrics.