### PR TITLE
Prevent unnecessary re-render of image

### DIFF
--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -8,7 +8,7 @@ import {
   useTheme,
 } from '@chakra-ui/react'
 import { FaImage } from '@react-icons/all-files/fa/FaImage'
-import { FC, useEffect, useState } from 'react'
+import { FC, useCallback, useEffect, useState } from 'react'
 import Image from '../Image/Image'
 
 const getUnlockedContentUrls = (
@@ -65,6 +65,9 @@ const TokenMedia: FC<{
   const [imageError, setImageError] = useState(false)
   const [videoError, setVideoError] = useState(false)
 
+  const onImageError = useCallback(() => setImageError(true), [])
+  const onVideoError = useCallback(() => setVideoError(true), [])
+
   // reset when image change. Needed when component is recycled
   useEffect(() => setImageError(false), [image])
   useEffect(() => setVideoError(false), [image, animation])
@@ -100,7 +103,7 @@ const TokenMedia: FC<{
         controls={controls}
         maxW="full"
         maxH="full"
-        onError={() => setVideoError(true)}
+        onError={onVideoError}
       />
     )
   }
@@ -118,7 +121,7 @@ const TokenMedia: FC<{
         controls={controls}
         maxW="full"
         maxH="full"
-        onError={() => setVideoError(true)}
+        onError={onVideoError}
       />
     )
   }
@@ -139,7 +142,7 @@ const TokenMedia: FC<{
       <Image
         src={image}
         alt={defaultText}
-        onError={() => setImageError(true)}
+        onError={onImageError}
         fill
         objectFit={fill ? 'cover' : 'contain'}
         sizes={sizes}


### PR DESCRIPTION
### Description

Prevent unnecessary re-render of image by simply wrapping the `onError` callbacks in `useCallback` in `Token/Media` component.
As functions (and object/array) are compared by memory address, defining the `onError` callback in the props of the components was re-rendering the underlying component at each render. Now even if `Token/Media` component is re-render, the image or video is not re-rendered.

### How to test

- Go to https://uaan.liteflow.com/collection/97/0xaeda941b728a7db17bfde95b88e99c251b9589bb
- Hover the NFT with the animated GIF
- Notice the animation restart every time its hover in and out
- Now go to https://nft-test-uaan-git-fix-token-media-image-refetch-liteflow.vercel.app/collection/97/0xaeda941b728a7db17bfde95b88e99c251b9589bb
- Hover the NFT with the animated GIF
- Animation is not restarted

---

- Go to https://uaan.liteflow.com/tokens/97-0xaeda941b728a7db17bfde95b88e99c251b9589bb-60249402084937876423066029128237587855293854847399148942219557800082430558231
- Notice the animation is restarted every 1sec
- Go to https://nft-test-uaan-git-fix-token-media-image-refetch-liteflow.vercel.app/tokens/97-0xaeda941b728a7db17bfde95b88e99c251b9589bb-60249402084937876423066029128237587855293854847399148942219557800082430558231
- Animation is not restarted

---

You can also test by disabling the cache in the network inspector and hovering any NFTs.
- Check the network inspector on https://uaan.liteflow.com/tokens/137-0xdf10cfb083075aae1880055ba44085f75686a986-3130
- And on https://nft-test-uaan-git-fix-token-media-image-refetch-liteflow.vercel.app/tokens/137-0xdf10cfb083075aae1880055ba44085f75686a986-3130

### Checklist

- [x] Base branch of the PR is `dev`
