### PR TITLE
Fix issue with currency autoreload

### DIFF
--- a/components/Offer/Form/Bid.tsx
+++ b/components/Offer/Form/Bid.tsx
@@ -104,14 +104,24 @@ const OfferFormBid: FC<Props> = (props) => {
     onClose: createOfferOnClose,
   } = useDisclosure()
 
-  const defaultAuctionExpirationValue = formatDateDatetime(
-    dayjs().add(auctionValidity, 'second').toISOString(),
+  const defaultAuctionExpirationValue = useMemo(
+    () =>
+      formatDateDatetime(dayjs().add(auctionValidity, 'second').toISOString()),
+    [auctionValidity],
   )
-  const defaultExpirationValue = formatDateDatetime(
-    dayjs().add(offerValidity, 'second').toISOString(),
+  const defaultExpirationValue = useMemo(
+    () =>
+      formatDateDatetime(dayjs().add(offerValidity, 'second').toISOString()),
+    [offerValidity],
   )
-  const minDate = formatDateDatetime(dayjs().add(1, 'day').toISOString())
-  const maxDate = formatDateDatetime(dayjs().add(1, 'year').toISOString())
+  const minDate = useMemo(
+    () => formatDateDatetime(dayjs().add(1, 'day').toISOString()),
+    [],
+  )
+  const maxDate = useMemo(
+    () => formatDateDatetime(dayjs().add(1, 'year').toISOString()),
+    [],
+  )
   const {
     register,
     handleSubmit,

--- a/components/Sales/Direct/Form.tsx
+++ b/components/Sales/Direct/Form.tsx
@@ -85,11 +85,19 @@ const SalesDirectForm: FC<Props> = ({
   const toast = useToast()
   const { isOpen, onOpen, onClose } = useDisclosure()
 
-  const defaultExpirationValue = formatDateDatetime(
-    dayjs().add(offerValidity, 'second').toISOString(),
+  const defaultExpirationValue = useMemo(
+    () =>
+      formatDateDatetime(dayjs().add(offerValidity, 'second').toISOString()),
+    [offerValidity],
   )
-  const minDate = formatDateDatetime(dayjs().add(1, 'day').toISOString())
-  const maxDate = formatDateDatetime(dayjs().add(1, 'year').toISOString())
+  const minDate = useMemo(
+    () => formatDateDatetime(dayjs().add(1, 'day').toISOString()),
+    [],
+  )
+  const maxDate = useMemo(
+    () => formatDateDatetime(dayjs().add(1, 'year').toISOString()),
+    [],
+  )
 
   const {
     register,


### PR DESCRIPTION
Fix the issue where the currency sometimes refreshes.
This issue is a bit tricky to detect/reproduce.

Flow to reproduce:

- Go on a create offer page (or bid)
- Select a currency that is not the default one
- Wait until your computer switches to the next minute
- Update the price
- Here you notice the currency changes

This issue is related to the fact that dates are not in memo, resulting in some refresh that should not happen.