### PR TITLE
Add symbol before name for wallet currencies

### DIFF
--- a/components/Wallet/Account/WalletBalanceList.tsx
+++ b/components/Wallet/Account/WalletBalanceList.tsx
@@ -45,7 +45,12 @@ const WalletBalanceList: FC<IProps> = ({ account, currencies }) => {
           label={x.symbol}
           subtitle={x.name}
           action={
-            <Text as="span" color="brand.black" fontWeight="medium">
+            <Text
+              as="span"
+              color="brand.black"
+              fontWeight="medium"
+              float="right"
+            >
               <WalletBalance account={account} currency={x} />
             </Text>
           }

--- a/components/Wallet/Account/WalletBalanceList.tsx
+++ b/components/Wallet/Account/WalletBalanceList.tsx
@@ -42,7 +42,8 @@ const WalletBalanceList: FC<IProps> = ({ account, currencies }) => {
               objectFit="cover"
             />
           }
-          label={x.name}
+          label={x.symbol}
+          subtitle={x.name}
           action={
             <Text as="span" color="brand.black" fontWeight="medium">
               <WalletBalance account={account} currency={x} />


### PR DESCRIPTION
### Project organization
- Related [trello card](https://trello.com/c/kR5K1IDf/1027-client-ticket-g2a-display-name-of-the-currency-in-selectors)

### Description
Add symbol before name for wallet currencies to keep consistency between price selector and wallet page.

### Checklist
- [x] Base branch of the PR is `dev`