### PR TITLE
Improve formatting of errors when coming from the API

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -49,6 +49,8 @@ export const formatError = (error: unknown): string | undefined => {
     return 'Transaction was cancelled'
   if ((error as any).error) return formatError((error as any).error)
   if ((error as any).data?.message) return formatError((error as any).data)
+  if ((error as any).response?.errors?.length >= 0)
+    return formatError((error as any).response.errors[0])
   if ((error as Error).message) return (error as Error).message
   return (error as any).toString()
 }


### PR DESCRIPTION
In some cases the API returns errors but the application is displaying the whole errors instead of just the message

<img width="454" alt="Screenshot 2023-09-06 at 11 59 13" src="https://github.com/liteflow-labs/starter-kit/assets/1783126/ff84189a-e54f-46c2-ac1a-4d78de3fa5e9">

This is now only "Auction can only start ... filled offer have expired"