### PR TITLE
Don't fetch invitation link if it's not going to be display

### DIFF
--- a/components/User/Profile/Info.tsx
+++ b/components/User/Profile/Info.tsx
@@ -59,6 +59,7 @@ const UserProfileInfo: FC<{
   useEffect(() => {
     if (!isLoggedIn) return
     if (referralUrl) return
+    if (!ownerLoggedIn) return
     if (!loginUrlForReferral) return
     if (!signer) return
     if (creatingReferralLink) return
@@ -78,6 +79,7 @@ const UserProfileInfo: FC<{
     toast,
     signer,
     creatingReferralLink,
+    ownerLoggedIn,
   ])
 
   const handleReferralCopyLink = useCallback(() => {


### PR DESCRIPTION
### Description

Don't fetch invitation link if it's not going to be display.
The link is only display on the user page of the logged in user, a check of variable `ownerLoggedIn` was missing.

### Checklist

- [x] Base branch of the PR is `dev`
