### PR TITLE
Add skeleton loader when fees are loading

### DIFF
--- a/components/Offer/Form/Checkout.tsx
+++ b/components/Offer/Form/Checkout.tsx
@@ -183,6 +183,7 @@ const OfferFormCheckout: FC<Props> = ({
           price={priceUnit}
           quantity={quantityBN}
           isSingle={!multiple}
+          noFees
         />
       </div>
 

--- a/components/Sales/Direct/Form.tsx
+++ b/components/Sales/Direct/Form.tsx
@@ -13,6 +13,7 @@ import {
   NumberInput,
   NumberInputField,
   NumberInputStepper,
+  Skeleton,
   Stack,
   Text,
   Tooltip,
@@ -135,7 +136,7 @@ const SalesDirectForm: FC<Props> = ({
   const priceUnit = useParseBigNumber(price, currency?.decimals)
   const quantityBN = useParseBigNumber(quantity)
 
-  const { feesPerTenThousand: _feesPerTenThousand } = useFees({
+  const { feesPerTenThousand, loading: loadingFees } = useFees({
     chainId,
     collectionAddress,
     tokenId,
@@ -143,22 +144,18 @@ const SalesDirectForm: FC<Props> = ({
     quantity: quantityBN,
     unitPrice: priceUnit,
   })
-  const feesPerTenThousand = useMemo(
-    () => _feesPerTenThousand ?? 0,
-    [_feesPerTenThousand],
-  )
 
   const amountFees = useMemo(() => {
-    if (!price) return BigNumber.from(0)
+    if (feesPerTenThousand === undefined) return
     return priceUnit.mul(feesPerTenThousand).div(10000)
-  }, [price, priceUnit, feesPerTenThousand])
+  }, [priceUnit, feesPerTenThousand])
 
   const amountRoyalties = useMemo(() => {
-    if (!price) return BigNumber.from(0)
     return priceUnit.mul(royaltiesPerTenThousand).div(10000)
-  }, [price, priceUnit, royaltiesPerTenThousand])
+  }, [priceUnit, royaltiesPerTenThousand])
 
   const priceWithFees = useMemo(() => {
+    if (amountFees === undefined) return
     return priceUnit.sub(amountFees).sub(isCreator ? 0 : amountRoyalties)
   }, [amountFees, priceUnit, amountRoyalties, isCreator])
 
@@ -387,17 +384,23 @@ const SalesDirectForm: FC<Props> = ({
       <Stack spacing={2}>
         {isSingle && (
           <>
-            <Text variant="text" color="gray.500">
-              {t('sales.direct.form.fees', { value: feesPerTenThousand / 100 })}
-              <Text
-                as={Price}
-                color="brand.black"
-                ml={1}
-                fontWeight="semibold"
-                amount={amountFees}
-                currency={currency}
-              />
-            </Text>
+            {feesPerTenThousand === undefined || amountFees === undefined ? (
+              <Skeleton noOfLines={1} height={4} width={200} mt={2} />
+            ) : (
+              <Text variant="text" color="gray.500">
+                {t('sales.direct.form.fees', {
+                  value: feesPerTenThousand / 100,
+                })}
+                <Text
+                  as={Price}
+                  color="brand.black"
+                  ml={1}
+                  fontWeight="semibold"
+                  amount={amountFees}
+                  currency={currency}
+                />
+              </Text>
+            )}
 
             <Text variant="text" color="gray.500">
               {t('sales.direct.form.royalties', {
@@ -412,25 +415,39 @@ const SalesDirectForm: FC<Props> = ({
                 currency={currency}
               />
             </Text>
+
+            {priceWithFees === undefined ? (
+              <Skeleton noOfLines={1} height={4} width={200} mt={2} />
+            ) : (
+              <Text variant="text" color="gray.500">
+                {t('sales.direct.form.receive-single')}
+                <Text
+                  as={Price}
+                  color="brand.black"
+                  ml={1}
+                  fontWeight="semibold"
+                  amount={priceWithFees}
+                  currency={currency}
+                />
+              </Text>
+            )}
           </>
         )}
 
-        <Text variant="text" color="gray.500">
-          {isSingle
-            ? t('sales.direct.form.receive-single')
-            : t('sales.direct.form.receive-multiple')}
-          <Text
-            as={Price}
-            color="brand.black"
-            ml={1}
-            fontWeight="semibold"
-            amount={isSingle ? priceWithFees : priceUnit}
-            currency={currency}
-          />
-        </Text>
-
         {!isSingle && (
           <>
+            <Text variant="text" color="gray.500">
+              {t('sales.direct.form.receive-multiple')}
+              <Text
+                as={Price}
+                color="brand.black"
+                ml={1}
+                fontWeight="semibold"
+                amount={priceUnit}
+                currency={currency}
+              />
+            </Text>
+
             <Text variant="text" color="gray.500">
               {t('sales.direct.form.quantity-for-sale')}
               <Text as="span" color="brand.black" ml={1} fontWeight="semibold">
@@ -440,19 +457,23 @@ const SalesDirectForm: FC<Props> = ({
               </Text>
             </Text>
 
-            <Text variant="text" color="gray.500">
-              {t('sales.direct.form.total-fees', {
-                value: feesPerTenThousand / 100,
-              })}
-              <Text
-                as={Price}
-                color="brand.black"
-                mx={1}
-                fontWeight="semibold"
-                amount={amountFees.mul(quantityBN)}
-                currency={currency}
-              />
-            </Text>
+            {feesPerTenThousand === undefined || amountFees === undefined ? (
+              <Skeleton noOfLines={1} height={4} width={200} mt={2} />
+            ) : (
+              <Text variant="text" color="gray.500">
+                {t('sales.direct.form.total-fees', {
+                  value: feesPerTenThousand / 100,
+                })}
+                <Text
+                  as={Price}
+                  color="brand.black"
+                  mx={1}
+                  fontWeight="semibold"
+                  amount={amountFees.mul(quantityBN)}
+                  currency={currency}
+                />
+              </Text>
+            )}
 
             <Text variant="text" color="gray.500">
               {t('sales.direct.form.total-royalties', {
@@ -468,17 +489,21 @@ const SalesDirectForm: FC<Props> = ({
               />
             </Text>
 
-            <Text variant="text" color="gray.500">
-              {t('sales.direct.form.total-receive')}
-              <Text
-                as={Price}
-                color="brand.black"
-                mx={1}
-                fontWeight="semibold"
-                amount={priceWithFees.mul(quantityBN)}
-                currency={currency}
-              />
-            </Text>
+            {priceWithFees === undefined ? (
+              <Skeleton noOfLines={1} height={4} width={200} mt={2} />
+            ) : (
+              <Text variant="text" color="gray.500">
+                {t('sales.direct.form.total-receive')}
+                <Text
+                  as={Price}
+                  color="brand.black"
+                  mx={1}
+                  fontWeight="semibold"
+                  amount={priceWithFees.mul(quantityBN)}
+                  currency={currency}
+                />
+              </Text>
+            )}
           </>
         )}
       </Stack>
@@ -486,6 +511,7 @@ const SalesDirectForm: FC<Props> = ({
       <ConnectButtonWithNetworkSwitch
         chainId={chainId}
         isLoading={activeStep !== CreateOfferStep.INITIAL}
+        isDisabled={loadingFees}
         size="lg"
         type="submit"
         width="full"


### PR DESCRIPTION
### Project organization

- Dependant on https://github.com/liteflow-labs/starter-kit/pull/408

### Description

- Add skeleton loader when fees are loading instead of displaying `0%`
- Disable create bid / offer button when fees are refetched with latest fee.

Before:

https://github.com/liteflow-labs/starter-kit/assets/5823445/58c7a97e-d441-44d9-b6ae-22c7ee0f628d

After:

https://github.com/liteflow-labs/starter-kit/assets/5823445/76bfb215-5381-4647-ab5f-6be12205695c

### Checklist

- [x] Base branch of the PR is `dev`