### PR TITLE
Add error management in edit account page

### DIFF
--- a/components/User/Form/Edit.tsx
+++ b/components/User/Form/Edit.tsx
@@ -41,9 +41,10 @@ type Props = {
     | 'website'
   >
   onUpdated: (address: string) => void
+  onError: (error: unknown) => void
 }
 
-const UserFormEdit: FC<Props> = ({ signer, account, onUpdated }) => {
+const UserFormEdit: FC<Props> = ({ signer, account, onUpdated, onError }) => {
   const { t } = useTranslation('components')
   const {
     control,
@@ -80,8 +81,12 @@ const UserFormEdit: FC<Props> = ({ signer, account, onUpdated }) => {
   const [editAccount] = useUpdateAccount(signer)
 
   const onSubmit = handleSubmit(async (data) => {
-    const address = await editAccount(data)
-    onUpdated(address)
+    try {
+      const address = await editAccount(data)
+      onUpdated(address)
+    } catch (error) {
+      onError(error)
+    }
   })
 
   return (

--- a/pages/account/edit.tsx
+++ b/pages/account/edit.tsx
@@ -12,6 +12,7 @@ import useAccount from '../../hooks/useAccount'
 import useLoginRedirect from '../../hooks/useLoginRedirect'
 import useSigner from '../../hooks/useSigner'
 import SmallLayout from '../../layouts/small'
+import { formatError } from '../../utils'
 
 const EditPage: NextPage = () => {
   const signer = useSigner()
@@ -29,7 +30,7 @@ const EditPage: NextPage = () => {
     skip: !isLoggedIn,
   })
 
-  const onSubmit = useCallback(
+  const onUpdated = useCallback(
     async (address: string) => {
       toast({
         title: t('users.form.notifications.updated'),
@@ -38,6 +39,16 @@ const EditPage: NextPage = () => {
       await push(`/users/${address}`)
     },
     [toast, t, push],
+  )
+
+  const onError = useCallback(
+    async (error: unknown) => {
+      toast({
+        title: formatError(error),
+        status: 'error',
+      })
+    },
+    [toast],
   )
 
   return (
@@ -52,7 +63,8 @@ const EditPage: NextPage = () => {
         ) : (
           <UserFormEdit
             signer={signer}
-            onUpdated={onSubmit}
+            onUpdated={onUpdated}
+            onError={onError}
             account={data.account}
           />
         )}


### PR DESCRIPTION
### Description

Add error management in edit account page.

On error, the submit button was actually stuck in the loading state.
Now the button is "released" and the error is displayed in a toast.

### Checklist

- [x] Base branch of the PR is `dev`