### PR TITLE
Buy collectibles quantity default value change

### DIFF
--- a/components/Offer/Form/Checkout.tsx
+++ b/components/Offer/Form/Checkout.tsx
@@ -23,7 +23,7 @@ import {
 import { Signer } from '@ethersproject/abstract-signer'
 import { useAcceptOffer } from '@liteflow/react'
 import useTranslation from 'next-translate/useTranslation'
-import { FC, useEffect, useMemo } from 'react'
+import { FC, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { Offer } from '../../../graphql'
 import useBalance from '../../../hooks/useBalance'
@@ -78,16 +78,7 @@ const OfferFormCheckout: FC<Props> = ({
     formState: { errors, isSubmitting },
     setValue,
     watch,
-  } = useForm<FormData>({
-    defaultValues: {
-      quantity: offer.availableQuantity,
-    },
-  })
-
-  useEffect(
-    () => setValue('quantity', offer.availableQuantity),
-    [offer.availableQuantity, setValue],
-  )
+  } = useForm<FormData>({ defaultValues: { quantity: '1' } })
 
   const quantity = watch('quantity')
 


### PR DESCRIPTION
### Project organization
- Related [trello card](https://trello.com/c/kUSJHnCq/1066-client-ticket-g2a-max-quantity-when-clicked-buy-collectibles)

### Description
Changes `defaultValue` for quantity that is used on Checkout page, so now, instead of choosing max available quantity, user will have 1 asset choosen as a default to buy.

### Checklist
- [x] Base branch of the PR is `dev`