### PR TITLE
Remove unused sales and bids from FetchCollectionAssets  query

### DIFF
--- a/pages/collection/[chainId]/[id].gql
+++ b/pages/collection/[chainId]/[id].gql
@@ -168,42 +168,6 @@ query FetchCollectionAssets(
           }
         }
       }
-      sales(
-        first: 1
-        orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } } # This filter should also be applied to the root query if sorting by sales. See getExtraFilterForSort function in utils/post/sorting.ts
-      ) {
-        nodes {
-          id
-          unitPrice
-          currency {
-            id
-            image
-            symbol
-            decimals
-          }
-          maker {
-            address
-          }
-        }
-      }
-      bids(
-        first: 1
-        orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } } # This filter should also be applied to the root query if sorting on by bids
-      ) {
-        nodes {
-          id
-          unitPrice
-          amount
-          currency {
-            image
-            id
-            decimals
-            symbol
-          }
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
### Description

Remove unused sales and bids from FetchCollectionAssets query.
I guess we forgot to remove this a long time ago.

### Checklist

- [x] Base branch of the PR is `dev`