### PR TITLE
Fix non display of 404 on token page

### DIFF
--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -100,7 +100,8 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
   })
 
   const asset = useMemo(() => {
-    if (!data?.asset) return undefined
+    if (data?.asset === null) return null
+    if (data?.asset === undefined) return undefined
     return {
       ...data.asset,
       image: { url: data.asset.image, mimetype: data.asset.imageMimetype },


### PR DESCRIPTION
### Description

Fix non display of 404 on token page by preserving both `null` and `undefined` possible type on asset

### How to test


Before, should display a 404 but actually display a loader:
https://dev.uaan.liteflow.com/tokens/1-0xe12edaab53023c75473a5a011bdb729ee73545e8-9991323232

After, display the 404:
https://nft-test-uaan-git-fix-token-page-404-liteflow.vercel.app/tokens/1-0xe12edaab53023c75473a5a011bdb729ee73545e8-9991323232

### Checklist

- [x] Base branch of the PR is `dev`