### PR TITLE
Refresh asset with updated `now` date to fetch only not-expired offers on refresh

### DIFF
--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -196,7 +196,9 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
   )
 
   const refresh = useCallback(async () => {
-    await refetch()
+    await refetch({
+      now: new Date(),
+    })
   }, [refetch])
 
   const refreshAsset = useRefreshAsset()
@@ -204,7 +206,7 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
     async (assetId: string) => {
       try {
         await refreshAsset(assetId)
-        await refetch()
+        await refresh()
         toast({
           title: 'Successfully refreshed metadata',
           status: 'success',
@@ -216,7 +218,7 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
         })
       }
     },
-    [refetch, refreshAsset, toast],
+    [refresh, refreshAsset, toast],
   )
 
   if (asset === null) return <Error statusCode={404} />


### PR DESCRIPTION
### Description

Refresh asset with updated `now` date to fetch only not-expired offers on refresh.

Since canceled offer are not deleted anymore but only their expired date are updated, there is a new issue where the canceled offer stays displayed and the button to cancel it is stuck in loading state:


https://github.com/liteflow-labs/starter-kit/assets/5823445/0f45a296-7bb9-4bef-8b3a-8f34cdeb9897

Now that the `now` param is updated to the current date, it behave normally:


https://github.com/liteflow-labs/starter-kit/assets/5823445/ca8ca716-5e76-4a2b-a89a-3cfd46f1a570

### Checklist

- [x] Base branch of the PR is `dev`