### PR TITLE
Optimize loading images on TokenCard component

### DIFF
--- a/components/Token/Card.tsx
+++ b/components/Token/Card.tsx
@@ -105,7 +105,7 @@ const TokenCard: FC<Props> = ({
   const { t } = useTranslation('templates')
   const isOwner = useMemo(() => asset.owned.gt('0'), [asset])
   const [isHovered, setIsHovered] = useState(false)
-  const media = useDetectAssetMedia(asset)
+  const media = useDetectAssetMedia({ ...asset, animation: null })
 
   const chainName = useMemo(
     () => CHAINS.find((x) => x.id === asset.collection.chainId)?.name,


### PR DESCRIPTION
### Project organization
- Related [trello card](https://trello.com/c/R1tnUerH/1106-feedback-g2a-optimize-of-loading-images)

### Description
From now on, TokenCard component will show only image field. Animation will not be used for thumbnail. Animation will still be active on Featured NFT section on homepage and NFT detail page. This is for the NFT cards that is shown on explore, user page etc.

### Checklist
- [x] Base branch of the PR is `dev`