### PR TITLE
Add cart button to the detail page and offer modal

### DIFF
--- a/components/Button/CheckoutButton.tsx
+++ b/components/Button/CheckoutButton.tsx
@@ -1,0 +1,52 @@
+import { Button, ButtonGroup, ButtonProps, Divider } from '@chakra-ui/react'
+import { JSX, PropsWithChildren, useMemo } from 'react'
+import useAccount from '../../hooks/useAccount'
+import { isSameAddress } from '../../utils'
+import Link from '../Link/Link'
+import AddToCartButton from './AddToCart'
+
+type Props = Omit<ButtonProps, 'href'> & {
+  offer: {
+    id: string
+    maker: { address: string }
+  }
+}
+
+export default function CheckoutButton({
+  offer,
+  children,
+  ...props
+}: PropsWithChildren<Props>): JSX.Element {
+  const { address } = useAccount()
+
+  const isDisabled = useMemo(
+    () => (address ? isSameAddress(address, offer.maker.address) : false),
+    [address, offer.maker],
+  )
+
+  return (
+    <ButtonGroup isAttached width="full" isDisabled={isDisabled}>
+      <Button
+        {...props}
+        width="full"
+        as={Link}
+        isDisabled={isDisabled}
+        href={isDisabled ? '#' : `/checkout/${offer.id}`}
+        borderRightRadius={address ? 0 : undefined}
+      >
+        {children}
+      </Button>
+      {address && (
+        <>
+          <Divider width="1px" />
+          <AddToCartButton
+            {...props}
+            borderLeftRadius={0}
+            offerId={offer.id}
+            isDisabled={isDisabled}
+          />
+        </>
+      )}
+    </ButtonGroup>
+  )
+}

--- a/components/Button/CheckoutButton.tsx
+++ b/components/Button/CheckoutButton.tsx
@@ -1,7 +1,6 @@
 import { Button, ButtonGroup, ButtonProps, Divider } from '@chakra-ui/react'
-import { JSX, PropsWithChildren, useMemo } from 'react'
+import { JSX, PropsWithChildren } from 'react'
 import useAccount from '../../hooks/useAccount'
-import { isSameAddress } from '../../utils'
 import Link from '../Link/Link'
 import AddToCartButton from './AddToCart'
 
@@ -19,32 +18,21 @@ export default function CheckoutButton({
 }: PropsWithChildren<Props>): JSX.Element {
   const { address } = useAccount()
 
-  const isDisabled = useMemo(
-    () => (address ? isSameAddress(address, offer.maker.address) : false),
-    [address, offer.maker],
-  )
-
   return (
-    <ButtonGroup isAttached width="full" isDisabled={isDisabled}>
+    <ButtonGroup isAttached width="full">
       <Button
         {...props}
         width="full"
         as={Link}
-        isDisabled={isDisabled}
-        href={isDisabled ? '#' : `/checkout/${offer.id}`}
+        href={`/checkout/${offer.id}`}
         borderRightRadius={address ? 0 : undefined}
       >
         {children}
       </Button>
       {address && (
         <>
-          <Divider width="1px" />
-          <AddToCartButton
-            {...props}
-            borderLeftRadius={0}
-            offerId={offer.id}
-            isDisabled={isDisabled}
-          />
+          <Divider orientation="vertical" />
+          <AddToCartButton {...props} borderLeftRadius={0} offerId={offer.id} />
         </>
       )}
     </ButtonGroup>

--- a/components/Sales/Direct/Button.tsx
+++ b/components/Sales/Direct/Button.tsx
@@ -4,6 +4,7 @@ import { HiArrowNarrowRight } from '@react-icons/all-files/hi/HiArrowNarrowRight
 import useTranslation from 'next-translate/useTranslation'
 import { FC, useMemo } from 'react'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
+import CheckoutButton from '../../Button/CheckoutButton'
 import Link from '../../Link/Link'
 import type { Props as ModalProps } from './Modal'
 import SaleDirectModal from './Modal'
@@ -55,16 +56,11 @@ const SaleDirectButton: FC<Props> = ({
     if (!sales[0]) return
     if (ownAllSupply) return
     return (
-      <Button
-        as={Link}
-        href={`/checkout/${sales[0].id}`}
-        size="lg"
-        width="full"
-      >
+      <CheckoutButton offer={sales[0]} size="lg">
         <Text as="span" isTruncated>
           {t('sales.direct.button.buy')}
         </Text>
-      </Button>
+      </CheckoutButton>
     )
   }, [sales, ownAllSupply, t])
 

--- a/components/Sales/Direct/ModalItem.tsx
+++ b/components/Sales/Direct/ModalItem.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  Flex,
-  Icon,
-  Text,
-  useDisclosure,
-  useToast,
-} from '@chakra-ui/react'
+import { Flex, Icon, Text, useDisclosure, useToast } from '@chakra-ui/react'
 import { Signer } from '@ethersproject/abstract-signer'
 import { BigNumber } from '@ethersproject/bignumber'
 import { CancelOfferStep, useCancelOffer } from '@liteflow/react'
@@ -14,6 +7,7 @@ import useTranslation from 'next-translate/useTranslation'
 import { FC, useCallback } from 'react'
 import { BlockExplorer } from '../../../hooks/useBlockExplorer'
 import { formatDate, formatError, isSameAddress } from '../../../utils'
+import CheckoutButton from '../../Button/CheckoutButton'
 import ConnectButtonWithNetworkSwitch from '../../Button/ConnectWithNetworkSwitch'
 import Link from '../../Link/Link'
 import { ListItem } from '../../List/List'
@@ -158,11 +152,11 @@ const SaleDirectModalItem: FC<Props> = ({
               </Text>
             </ConnectButtonWithNetworkSwitch>
           ) : (
-            <Button as={Link} href={`/checkout/${sale.id}`}>
+            <CheckoutButton offer={sale}>
               <Text as="span" isTruncated>
                 {t('sales.direct.modal-item.buy')}
               </Text>
-            </Button>
+            </CheckoutButton>
           )
         }
       />


### PR DESCRIPTION
Add missing "add to cart" button by creating a dedicated "checkout" button

<img width="841" alt="Screenshot 2023-11-22 at 18 57 56" src="https://github.com/liteflow-labs/starter-kit/assets/1783126/d585c4a3-cbcb-4f84-bd05-b33c44b83c7d">
<img width="645" alt="Screenshot 2023-11-22 at 18 58 08" src="https://github.com/liteflow-labs/starter-kit/assets/1783126/c203c810-f450-4709-9c99-d3c3dc16d956">

@ismailToyran could you check that there is no other places where we need to add that