### PR TITLE
Fix wrong order by type use in users/bids/placed and received page

### DIFF
--- a/pages/users/[id]/bids/placed.tsx
+++ b/pages/users/[id]/bids/placed.tsx
@@ -31,10 +31,7 @@ import Pagination from '../../../../components/Pagination/Pagination'
 import Price from '../../../../components/Price/Price'
 import UserProfileTemplate from '../../../../components/Profile'
 import Select from '../../../../components/Select/Select'
-import {
-  OfferOpenBuysOrderBy,
-  useFetchUserBidsPlacedQuery,
-} from '../../../../graphql'
+import { OffersOrderBy, useFetchUserBidsPlacedQuery } from '../../../../graphql'
 import useEnvironment from '../../../../hooks/useEnvironment'
 import useOrderByQuery from '../../../../hooks/useOrderByQuery'
 import usePaginate from '../../../../hooks/usePaginate'
@@ -48,7 +45,7 @@ const BidPlacedPage: NextPage = () => {
   const { t } = useTranslation('templates')
   const { replace, pathname, query } = useRouter()
   const { limit, offset, page } = usePaginateQuery()
-  const orderBy = useOrderByQuery<OfferOpenBuysOrderBy>('CREATED_AT_DESC')
+  const orderBy = useOrderByQuery<OffersOrderBy>('CREATED_AT_DESC')
   const { changeLimit } = usePaginate()
   const toast = useToast()
   const userAddress = useRequiredQueryParamSingle('id')
@@ -126,7 +123,7 @@ const BidPlacedPage: NextPage = () => {
               </Link>
             </Flex>
             <Box ml="auto" w={{ base: 'full', md: 'min-content' }}>
-              <Select<OfferOpenBuysOrderBy>
+              <Select<OffersOrderBy>
                 label={t('user.bid-placed.orderBy.label')}
                 name="Sort by"
                 onChange={changeOrder}

--- a/pages/users/[id]/bids/received.tsx
+++ b/pages/users/[id]/bids/received.tsx
@@ -33,7 +33,7 @@ import UserProfileTemplate from '../../../../components/Profile'
 import Select from '../../../../components/Select/Select'
 import Avatar from '../../../../components/User/Avatar'
 import {
-  OfferOpenBuysOrderBy,
+  OffersOrderBy,
   useFetchUserBidsReceivedQuery,
 } from '../../../../graphql'
 import useEnvironment from '../../../../hooks/useEnvironment'
@@ -53,7 +53,7 @@ const BidReceivedPage: NextPage<Props> = ({ now }) => {
   const { t } = useTranslation('templates')
   const { replace, pathname, query } = useRouter()
   const { limit, offset, page } = usePaginateQuery()
-  const orderBy = useOrderByQuery<OfferOpenBuysOrderBy>('CREATED_AT_DESC')
+  const orderBy = useOrderByQuery<OffersOrderBy>('CREATED_AT_DESC')
   const { changeLimit } = usePaginate()
   const toast = useToast()
   const userAddress = useRequiredQueryParamSingle('id')
@@ -133,7 +133,7 @@ const BidReceivedPage: NextPage<Props> = ({ now }) => {
               </Link>
             </Flex>
             <Box ml="auto" w={{ base: 'full', md: 'min-content' }}>
-              <Select<OfferOpenBuysOrderBy>
+              <Select<OffersOrderBy>
                 label={t('user.bid-received.orderBy.label')}
                 name="Sort by"
                 onChange={changeOrder}


### PR DESCRIPTION
### Description

The queries are on `offers` but the order by type used was `OfferOpenBuysOrderBy` instead of `OffersOrderBy`.

### Checklist

- [x] Base branch of the PR is `dev`