### PR TITLE
Rename enum `OfferFilter` to `OfferFilterType`

### DIFF
--- a/components/Filter/FilterAsset.tsx
+++ b/components/Filter/FilterAsset.tsx
@@ -18,7 +18,7 @@ import { NextPage } from 'next'
 import useTranslation from 'next-translate/useTranslation'
 import { useCallback, useEffect, useMemo } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
-import { Filter, OfferFilter } from '../../hooks/useAssetFilterFromQuery'
+import { Filter, OfferFilterType } from '../../hooks/useAssetFilterFromQuery'
 import useEnvironment from '../../hooks/useEnvironment'
 import Image from '../Image/Image'
 import FilterByCollection from './FilterBy/Collection'
@@ -58,8 +58,8 @@ export const NoFilter: Filter = {
 
 const offerTypes = [
   { key: 'all', value: null },
-  { key: 'fixed', value: OfferFilter.fixed },
-  { key: 'auction', value: OfferFilter.auction },
+  { key: 'fixed', value: OfferFilterType.fixed },
+  { key: 'auction', value: OfferFilterType.auction },
 ]
 
 const FilterAsset: NextPage<Props> = ({

--- a/hooks/useAssetFilterFromQuery.ts
+++ b/hooks/useAssetFilterFromQuery.ts
@@ -26,7 +26,7 @@ export type Filter = {
   minPrice: number | null
   maxPrice: number | null
   collection: string | null
-  offers: OfferFilter | null
+  offers: OfferFilterType | null
   currency: {
     id: string
     decimals: number
@@ -36,7 +36,7 @@ export type Filter = {
   propertySearch?: string
 }
 
-export enum OfferFilter {
+export enum OfferFilterType {
   fixed = 'fixed',
   auction = 'auction',
 }
@@ -117,8 +117,8 @@ const maxPriceFilter = (
     } as AssetToManyOfferOpenSaleFilter,
   } as AssetFilter)
 
-const offersFilter = (offers: OfferFilter, date: Date): AssetFilter => {
-  if (offers === OfferFilter.auction) {
+const offersFilter = (offers: OfferFilterType, date: Date): AssetFilter => {
+  if (offers === OfferFilterType.auction) {
     return {
       auctions: {
         some: {
@@ -127,7 +127,7 @@ const offersFilter = (offers: OfferFilter, date: Date): AssetFilter => {
       } as AssetToManyAuctionFilter,
     } as AssetFilter
   }
-  if (offers === OfferFilter.fixed) {
+  if (offers === OfferFilterType.fixed) {
     return {
       sales: {
         some: {
@@ -192,7 +192,7 @@ export default function useAssetFilterFromQuery(): Filter {
   const minPrice = useQueryParamSingle('minPrice', { parse: parseToFloat })
   const maxPrice = useQueryParamSingle('maxPrice', { parse: parseToFloat })
   const collection = useQueryParamSingle('collection')
-  const offers = useQueryParamSingle<OfferFilter>('offers')
+  const offers = useQueryParamSingle<OfferFilterType>('offers')
   const currencyId = useQueryParamSingle('currency')
   const currencyDecimals = useQueryParamSingle('decimals', {
     parse: parseToInt,


### PR DESCRIPTION
### Description

Rename enum `OfferFilter` to `OfferFilterType` to be able to use `OfferFilter` from the GraphQL schema without renaming in an upcoming PR.

### Checklist

- [x] Base branch of the PR is `dev`