### PR TITLE
Refactor Text to use div instead of p element

### DIFF
--- a/components/User/Profile/Info.tsx
+++ b/components/User/Profile/Info.tsx
@@ -132,7 +132,12 @@ const UserProfileInfo: FC<Props> = ({ address, user, loginUrlForReferral }) => {
           <Heading as="h4" variant="heading2" color="brand.black">
             {t('user.info.bio')}
           </Heading>
-          <Text variant="text-sm" color="gray.500" whiteSpace="pre-wrap">
+          <Text
+            as="div"
+            variant="text-sm"
+            color="gray.500"
+            whiteSpace="pre-wrap"
+          >
             <MarkdownViewer source={user.description} />
           </Text>
         </Stack>

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -263,6 +263,7 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
                   </Heading>
                   <Stack borderRadius="2xl" p={3} borderWidth="1px">
                     <Text
+                      as="div"
                       variant="text-sm"
                       color="gray.500"
                       whiteSpace="pre-wrap"


### PR DESCRIPTION
### Project organization
- Closes #503 

### Description
Change the wrapper of MarkdownViewer component to be `div` so it doesn't throw `<div> cannot appear as a descendant of <p>` error

### Checklist
- [x] Base branch of the PR is `dev`