### PR TITLE
Refactor MarkdownViewer component display and height properties

### DIFF
--- a/components/MarkdownViewer.tsx
+++ b/components/MarkdownViewer.tsx
@@ -77,11 +77,9 @@ const MarkdownViewer: FC<MarkdownPreviewProps> = ({ source, ...props }) => {
             hr: () => <></>,
           }}
           style={{
-            display: isOpen ? 'flex' : '-webkit-box',
-            WebkitLineClamp: 1,
+            display: 'flex',
+            height: isOpen ? 'auto' : '24px',
             overflow: isOpen ? 'visible' : 'hidden',
-            textOverflow: 'ellipsis',
-            WebkitBoxOrient: 'vertical',
           }}
           source={source}
           {...props}


### PR DESCRIPTION
### Description
If description is only 1 paragraph, previous PR doesn't fix that. And there is a new issue with that case.
This PR should fix that.

### Checklist
- [x] Base branch of the PR is `dev`