### PR TITLE
Display deleted data

### DIFF
--- a/components/History/HistoryList.gql
+++ b/components/History/HistoryList.gql
@@ -19,6 +19,8 @@ query FetchAssetHistory(
       orderBy: DATE_DESC
       first: $limit
       offset: $offset
+      includeWhenAssetDeleted: YES
+      includeWhenCurrencyDeleted: YES
     ) {
       pageInfo {
         hasNextPage

--- a/layouts/navbar.gql
+++ b/layouts/navbar.gql
@@ -3,7 +3,11 @@ query NavbarAccount($account: Address!, $lastNotification: Datetime!) {
     address
     name
     image
-    notifications(filter: { createdAt: { greaterThan: $lastNotification } }) {
+    notifications(
+      filter: { createdAt: { greaterThan: $lastNotification } }
+      includeWhenCollectionDeleted: YES
+      includeWhenTradeDeleted: YES
+    ) {
       totalCount
     }
   }

--- a/pages/checkout/[id].gql
+++ b/pages/checkout/[id].gql
@@ -22,6 +22,7 @@ query Checkout($id: UUID!) {
       id
       decimals
       symbol
+      deletedAt
     }
   }
 }
@@ -39,6 +40,7 @@ query FetchAssetForCheckout(
     tokenId: $tokenId
   ) {
     id
+    deletedAt
     chainId
     collectionAddress
     tokenId

--- a/pages/checkout/[id].tsx
+++ b/pages/checkout/[id].tsx
@@ -74,7 +74,12 @@ const CheckoutPage: NextPage<Props> = ({ now }) => {
     await push(`/tokens/${asset.id}`)
   }, [asset, toast, t, push])
 
-  if (offer === null || asset === null) {
+  if (
+    offer === null ||
+    asset === null ||
+    asset?.deletedAt ||
+    offer?.currency.deletedAt
+  ) {
     return <Error statusCode={404} />
   }
   return (

--- a/pages/collection/[chainId]/[id]/index.gql
+++ b/pages/collection/[chainId]/[id]/index.gql
@@ -2,6 +2,7 @@ query FetchCollectionDetails($collectionAddress: Address!, $chainId: Int!) {
   collection(address: $collectionAddress, chainId: $chainId) {
     address
     chainId
+    deletedAt
     cover
     image
     name

--- a/pages/collection/[chainId]/[id]/index.tsx
+++ b/pages/collection/[chainId]/[id]/index.tsx
@@ -148,7 +148,8 @@ const CollectionPage: FC<Props> = ({ now }) => {
 
   const { changeLimit } = usePaginate()
 
-  if (collection === null) return <Error statusCode={404} />
+  if (collection === null || collection?.deletedAt)
+    return <Error statusCode={404} />
   return (
     <LargeLayout>
       <Head

--- a/pages/create/[chainId]/[collectionAddress].gql
+++ b/pages/create/[chainId]/[collectionAddress].gql
@@ -16,5 +16,6 @@ query FetchAccountAndCollection(
     address
     name
     standard
+    deletedAt
   }
 }

--- a/pages/create/[chainId]/[collectionAddress].tsx
+++ b/pages/create/[chainId]/[collectionAddress].tsx
@@ -100,7 +100,8 @@ const CreatePage: NextPage = () => {
     [push, t, toast],
   )
 
-  if (collection === null) return <Error statusCode={404} />
+  if (collection === null || collection?.deletedAt)
+    return <Error statusCode={404} />
   return (
     <SmallLayout>
       <Head

--- a/pages/notification.gql
+++ b/pages/notification.gql
@@ -17,6 +17,8 @@ query GetNotifications($address: Address!, $cursor: Cursor) {
     first: 12
     orderBy: CREATED_AT_DESC
     after: $cursor
+    includeWhenCollectionDeleted: YES
+    includeWhenTradeDeleted: YES
   ) {
     pageInfo {
       hasNextPage

--- a/pages/tokens/[id]/bid.gql
+++ b/pages/tokens/[id]/bid.gql
@@ -11,6 +11,7 @@ query BidOnAsset(
     tokenId: $tokenId
   ) {
     id
+    deletedAt
     chainId
     collectionAddress
     tokenId

--- a/pages/tokens/[id]/bid.tsx
+++ b/pages/tokens/[id]/bid.tsx
@@ -52,7 +52,7 @@ const BidPage: NextPage<Props> = ({ now }) => {
     await push(`/tokens/${assetId}`)
   }, [toast, t, push, assetId])
 
-  if (asset === null) return <Error statusCode={404} />
+  if (asset === null || asset?.deletedAt) return <Error statusCode={404} />
   return (
     <SmallLayout>
       <Head

--- a/pages/tokens/[id]/index.gql
+++ b/pages/tokens/[id]/index.gql
@@ -11,6 +11,7 @@ query FetchAsset(
     tokenId: $tokenId
   ) {
     id
+    deletedAt
     tokenId
     tokenUri
     chainId

--- a/pages/tokens/[id]/index.tsx
+++ b/pages/tokens/[id]/index.tsx
@@ -140,7 +140,7 @@ const DetailPage: NextPage<Props> = ({ now: nowProp }) => {
     [refresh, refreshAsset, toast],
   )
 
-  if (asset === null) return <Error statusCode={404} />
+  if (asset === null || asset?.deletedAt) return <Error statusCode={404} />
   return (
     <LargeLayout>
       <Head

--- a/pages/tokens/[id]/offer.gql
+++ b/pages/tokens/[id]/offer.gql
@@ -11,6 +11,7 @@ query OfferForAsset(
     tokenId: $tokenId
   ) {
     id
+    deletedAt
     chainId
     collectionAddress
     tokenId

--- a/pages/tokens/[id]/offer.tsx
+++ b/pages/tokens/[id]/offer.tsx
@@ -63,7 +63,7 @@ const OfferPage: NextPage<Props> = ({ now }) => {
     await push(`/tokens/${assetId}`)
   }, [toast, t, push, assetId])
 
-  if (asset === null) return <Error statusCode={404} />
+  if (asset === null || asset?.deletedAt) return <Error statusCode={404} />
   return (
     <SmallLayout>
       <Head

--- a/pages/users/[id]/bids/placed.gql
+++ b/pages/users/[id]/bids/placed.gql
@@ -14,6 +14,8 @@ query FetchUserBidsPlaced(
       signature: { isNull: false }
       makerAddress: { equalTo: $address }
     }
+    includeWhenAssetDeleted: YES
+    includeWhenCurrencyDeleted: YES
   ) {
     pageInfo {
       hasNextPage
@@ -49,6 +51,7 @@ query FetchUserBidsPlaced(
         name
         image
         imageMimetype
+        deletedAt
       }
     }
   }

--- a/pages/users/[id]/bids/placed.tsx
+++ b/pages/users/[id]/bids/placed.tsx
@@ -163,7 +163,11 @@ const BidPlacedPage: NextPage = () => {
                       <Td>
                         <Flex
                           as={Link}
-                          href={`/tokens/${item.asset.id}`}
+                          href={
+                            item.asset.deletedAt
+                              ? undefined // no link if asset is deleted
+                              : `/tokens/${item.asset.id}`
+                          }
                           gap={3}
                         >
                           <Image
@@ -239,7 +243,11 @@ const BidPlacedPage: NextPage = () => {
                             ) : (
                               <Button
                                 as={Link}
-                                href={`/tokens/${item.asset.id}/bid`}
+                                href={
+                                  item.asset.deletedAt
+                                    ? undefined // no link if asset is deleted
+                                    : `/tokens/${item.asset.id}/bid`
+                                }
                                 variant="outline"
                                 colorScheme="gray"
                               >

--- a/pages/users/[id]/bids/received.gql
+++ b/pages/users/[id]/bids/received.gql
@@ -17,6 +17,8 @@ query FetchUserBidsReceived(
       makerAddress: { notEqualTo: $address }
       asset: { ownerships: { some: { ownerAddress: { equalTo: $address } } } }
     }
+    includeWhenAssetDeleted: YES
+    includeWhenCurrencyDeleted: YES
   ) {
     pageInfo {
       hasNextPage
@@ -43,6 +45,7 @@ query FetchUserBidsReceived(
         id
         decimals
         symbol
+        deletedAt
       }
       asset {
         id
@@ -52,6 +55,7 @@ query FetchUserBidsReceived(
         name
         image
         imageMimetype
+        deletedAt
       }
     }
   }

--- a/pages/users/[id]/bids/received.tsx
+++ b/pages/users/[id]/bids/received.tsx
@@ -172,7 +172,11 @@ const BidReceivedPage: NextPage<Props> = ({ now }) => {
                       <Td>
                         <Flex
                           as={Link}
-                          href={`/tokens/${item.asset.id}`}
+                          href={
+                            item.asset.deletedAt
+                              ? undefined // no link if asset is deleted
+                              : `/tokens/${item.asset.id}`
+                          }
                           gap={3}
                         >
                           <Image
@@ -223,25 +227,27 @@ const BidReceivedPage: NextPage<Props> = ({ now }) => {
                       </Td>
                       <Td>{dateFromNow(item.createdAt)}</Td>
                       <Td isNumeric>
-                        {ownerLoggedIn && (
-                          <AcceptOfferButton
-                            offer={item}
-                            title={t('user.bid-received.accept.title')}
-                            variant="outline"
-                            colorScheme="gray"
-                            onAccepted={onAccepted}
-                            onError={(e) =>
-                              toast({
-                                status: 'error',
-                                title: formatError(e),
-                              })
-                            }
-                          >
-                            <Text as="span" isTruncated>
-                              {t('user.bid-received.actions.accept')}
-                            </Text>
-                          </AcceptOfferButton>
-                        )}
+                        {ownerLoggedIn &&
+                          !item.asset.deletedAt && // only display accept button if asset and currency are not deleted
+                          !item.currency.deletedAt && (
+                            <AcceptOfferButton
+                              offer={item}
+                              title={t('user.bid-received.accept.title')}
+                              variant="outline"
+                              colorScheme="gray"
+                              onAccepted={onAccepted}
+                              onError={(e) =>
+                                toast({
+                                  status: 'error',
+                                  title: formatError(e),
+                                })
+                              }
+                            >
+                              <Text as="span" isTruncated>
+                                {t('user.bid-received.actions.accept')}
+                              </Text>
+                            </AcceptOfferButton>
+                          )}
                       </Td>
                     </Tr>
                   ))}

--- a/pages/users/[id]/offers.gql
+++ b/pages/users/[id]/offers.gql
@@ -13,6 +13,8 @@ query FetchUserFixedPrice(
       signature: { isNull: false }
       makerAddress: { equalTo: $address }
     }
+    includeWhenAssetDeleted: YES
+    includeWhenCurrencyDeleted: : YES
   ) {
     pageInfo {
       hasNextPage
@@ -43,6 +45,7 @@ query FetchUserFixedPrice(
         owned: ownership(ownerAddress: $address) {
           quantity
         }
+        deletedAt
       }
       currency {
         id
@@ -50,6 +53,7 @@ query FetchUserFixedPrice(
         image
         decimals
         symbol
+        deletedAt
       }
     }
   }

--- a/pages/users/[id]/offers.tsx
+++ b/pages/users/[id]/offers.tsx
@@ -134,7 +134,11 @@ const FixedPricePage: NextPage = () => {
                       <Td>
                         <Flex
                           as={Link}
-                          href={`/tokens/${item.asset.id}`}
+                          href={
+                            item.asset.deletedAt
+                              ? undefined // no link if asset is deleted
+                              : `/tokens/${item.asset.id}`
+                          }
                           gap={3}
                         >
                           <Image
@@ -207,7 +211,9 @@ const FixedPricePage: NextPage = () => {
                               </CancelOfferButton>
                             ) : BigNumber.from(
                                 item.asset.owned?.quantity || 0,
-                              ).gt(0) ? (
+                              ).gt(0) &&
+                              !item.asset.deletedAt && // only display new button if asset and currency are not deleted
+                              !item.currency.deletedAt ? (
                               <Button
                                 as={Link}
                                 href={`/tokens/${item.asset.id}/offer`}

--- a/pages/users/[id]/trades/purchased.gql
+++ b/pages/users/[id]/trades/purchased.gql
@@ -9,6 +9,9 @@ query FetchUserTradePurchased(
     first: $limit
     offset: $offset
     filter: { buyerAddress: { equalTo: $address } }
+    includeWhenAssetDeleted: YES
+    includeWhenCollectionDeleted: YES
+    includeWhenCurrencyDeleted: YES
   ) {
     pageInfo {
       hasNextPage

--- a/pages/users/[id]/trades/purchased.gql
+++ b/pages/users/[id]/trades/purchased.gql
@@ -47,6 +47,7 @@ query FetchUserTradePurchased(
         name
         imageMimetype
         image
+        deletedAt
       }
     }
   }

--- a/pages/users/[id]/trades/purchased.tsx
+++ b/pages/users/[id]/trades/purchased.tsx
@@ -173,7 +173,11 @@ const TradePurchasedPage: NextPage = () => {
                         {item.asset ? (
                           <Flex
                             as={Link}
-                            href={`/tokens/${item.asset.id}`}
+                            href={
+                              item.asset.deletedAt
+                                ? undefined // no link if asset is deleted
+                                : `/tokens/${item.asset.id}`
+                            }
                             gap={3}
                           >
                             <Image

--- a/pages/users/[id]/trades/sold.gql
+++ b/pages/users/[id]/trades/sold.gql
@@ -47,6 +47,7 @@ query FetchUserTradeSold(
         name
         image
         imageMimetype
+        deletedAt
       }
     }
   }

--- a/pages/users/[id]/trades/sold.gql
+++ b/pages/users/[id]/trades/sold.gql
@@ -9,6 +9,9 @@ query FetchUserTradeSold(
     first: $limit
     offset: $offset
     filter: { sellerAddress: { equalTo: $address } }
+    includeWhenAssetDeleted: YES
+    includeWhenCollectionDeleted: YES
+    includeWhenCurrencyDeleted: YES
   ) {
     pageInfo {
       hasNextPage

--- a/pages/users/[id]/trades/sold.tsx
+++ b/pages/users/[id]/trades/sold.tsx
@@ -165,7 +165,11 @@ const TradeSoldPage: NextPage = () => {
                         {item.asset ? (
                           <Flex
                             as={Link}
-                            href={`/tokens/${item.asset.id}`}
+                            href={
+                              item.asset.deletedAt
+                                ? undefined // no link if asset is deleted
+                                : `/tokens/${item.asset.id}`
+                            }
                             gap={3}
                           >
                             <Image


### PR DESCRIPTION
### Description

- display history related to deleted data in AssetHistory query
- display notifications of deleted collection and trades. I didn't remove any links because neither point to the token page, they all point to user activity pages
- display trades related to deleted assets and currencies in pages `users/trades/purchased`, and `users/trades/sold`
  - disable links to asset page
- display offers related to deleted assets and currencies in pages `users/bids/placed`, `users/bids/received`, and `users/offers`
  - disable links to asset page and button to accept or create new bid
- display 404:
  - if asset is deleted on pages tokens
  - if collection is deleted on collection pages
  - if asset or currency is deleted on checkout page

### Checklist

- [x] Base branch of the PR is `dev`
