### PR TITLE
Properly activate prettier-plugin-organize-import

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,4 +3,5 @@ module.exports = {
   trailingComma: 'all',
   semi: false,
   printWidth: 80,
+  plugins: ['prettier-plugin-organize-imports'],
 }


### PR DESCRIPTION
### Description

Properly activate prettier-plugin-organize-import by adding it to plugins in `.prettierrc`. This is required since prettier v3 (https://github.com/simonhaenisch/prettier-plugin-organize-imports?tab=readme-ov-file#prettier-3).

### Checklist

- [x] Base branch of the PR is `dev`