### PR TITLE
Replace deprecated `valuePerTenThousand` in `useFees` query

### DIFF
--- a/components/Offer/Summary.tsx
+++ b/components/Offer/Summary.tsx
@@ -12,7 +12,7 @@ type Props = {
   isSingle: boolean
   price: BigNumber
   quantity: BigNumber
-  feesOnTopPerTenThousand?: number | undefined
+  feesOnTopPerTenThousand?: BigNumber | undefined
   noFees?: boolean
 }
 
@@ -66,7 +66,7 @@ const Summary: FC<Props> = ({
           ) : (
             <Heading as={Flex} variant="heading3" color="gray.500" mb={2}>
               {t('offer.summary.fees', {
-                value: feesOnTopPerTenThousand / 100,
+                value: feesOnTopPerTenThousand.div(100).toString(),
               })}
               <Text
                 as={Price}

--- a/components/Sales/Direct/Form.tsx
+++ b/components/Sales/Direct/Form.tsx
@@ -408,7 +408,7 @@ const SalesDirectForm: FC<Props> = ({ asset, currencies, onCreated }) => {
             ) : (
               <Text variant="text" color="gray.500">
                 {t('sales.direct.form.fees', {
-                  value: feesPerTenThousand / 100,
+                  value: feesPerTenThousand.div(100).toString(),
                 })}
                 <Text
                   as={Price}
@@ -481,7 +481,7 @@ const SalesDirectForm: FC<Props> = ({ asset, currencies, onCreated }) => {
             ) : (
               <Text variant="text" color="gray.500">
                 {t('sales.direct.form.total-fees', {
-                  value: feesPerTenThousand / 100,
+                  value: feesPerTenThousand.div(100).toString(),
                 })}
                 <Text
                   as={Price}

--- a/hooks/useFees.gql
+++ b/hooks/useFees.gql
@@ -14,6 +14,7 @@ query Fees(
     unitPrice: $unitPrice
     tokenId: $tokenId
   ) {
-    valuePerTenThousand
+    value
+    precision
   }
 }

--- a/hooks/useFees.ts
+++ b/hooks/useFees.ts
@@ -64,10 +64,11 @@ export default function useFees({
     tokenId,
   ])
 
-  const feesPerTenThousand = useMemo(
-    () => (data?.orderFees || previousData?.orderFees)?.valuePerTenThousand,
-    [data?.orderFees, previousData?.orderFees],
-  )
+  const feesPerTenThousand = useMemo(() => {
+    const value = (data?.orderFees || previousData?.orderFees)?.value
+    if (value === undefined) return undefined
+    return BigNumber.from(value) // TODO: take into account orderFees.precision
+  }, [data?.orderFees, previousData?.orderFees])
 
   return {
     feesPerTenThousand,


### PR DESCRIPTION
### Description

Replace deprecated `valuePerTenThousand` in `useFees` query

### Checklist

- [x] Base branch of the PR is `dev`