### PR TITLE
Use bestBid and sales custom resolvers on asset instead of bids and sales connection

### DIFF
--- a/components/HomeSection/Assets.gql
+++ b/components/HomeSection/Assets.gql
@@ -49,21 +49,15 @@ query FetchAssets(
       owned: ownership(ownerAddress: $address) {
         quantity
       }
-      bestBid: bids(
-        orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-        first: 1
-      ) {
-        nodes {
-          unitPrice
-          amount
-          currency {
-            image
-            name
-            id
-            decimals
-            symbol
-          }
+      bestBid {
+        unitPrice
+        amount
+        currency {
+          image
+          name
+          id
+          decimals
+          symbol
         }
       }
       firstSale: sales(

--- a/components/HomeSection/Assets.gql
+++ b/components/HomeSection/Assets.gql
@@ -14,7 +14,6 @@ query FetchDefaultAssetIds($limit: Int!) {
 }
 
 query FetchAssets(
-  $now: Datetime!
   $limit: Int!
   $assetIds: [String!]!
   $address: Address
@@ -60,28 +59,22 @@ query FetchAssets(
           symbol
         }
       }
-      firstSale: sales(
-        first: 1
-        orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-      ) {
-        totalCount
-        totalCurrencyDistinctCount
-        nodes {
+      firstSale {
+        id
+        unitPrice
+        currency {
+          image
+          name
           id
-          unitPrice
-          currency {
-            image
-            name
-            id
-            decimals
-            symbol
-          }
-          maker {
-            address
-          }
+          decimals
+          symbol
+        }
+        maker {
+          address
         }
       }
+      totalSalesCount
+      totalSalesCurrencyDistinctCount
     }
   }
 }

--- a/components/HomeSection/Assets.gql
+++ b/components/HomeSection/Assets.gql
@@ -13,11 +13,7 @@ query FetchDefaultAssetIds($limit: Int!) {
   }
 }
 
-query FetchAssets(
-  $limit: Int!
-  $assetIds: [String!]!
-  $address: Address
-) {
+query FetchAssets($limit: Int!, $assetIds: [String!]!, $address: Address) {
   assets(
     filter: { quantity: { greaterThan: "0" }, id: { in: $assetIds } }
     first: $limit

--- a/components/HomeSection/Assets.tsx
+++ b/components/HomeSection/Assets.tsx
@@ -62,7 +62,6 @@ const AssetsHomeSection: FC<Props> = ({ date }) => {
 
   const assetsQuery = useFetchAssetsQuery({
     variables: {
-      now: date,
       limit: PAGINATION_LIMIT,
       assetIds: assetIds || [],
       address: address || '',

--- a/components/HomeSection/Featured.gql
+++ b/components/HomeSection/Featured.gql
@@ -55,21 +55,15 @@ query FetchFeaturedAssets(
           }
         }
       }
-      bestBid: bids(
-        orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-        first: 1
-      ) {
-        nodes {
-          unitPrice
-          amount
-          currency {
-            image
-            name
-            id
-            decimals
-            symbol
-          }
+      bestBid {
+        unitPrice
+        amount
+        currency {
+          image
+          name
+          id
+          decimals
+          symbol
         }
       }
       sales(

--- a/components/Sales/Open/CardFooter.tsx
+++ b/components/Sales/Open/CardFooter.tsx
@@ -6,15 +6,13 @@ import Price from '../../Price/Price'
 
 type Props = {
   assetId: string
-  bestBid:
-    | {
-        unitPrice: string
-        currency: {
-          decimals: number
-          symbol: string
-        }
-      }
-    | undefined
+  bestBid: {
+    unitPrice: string
+    currency: {
+      decimals: number
+      symbol: string
+    }
+  } | null
   isOwner: boolean
   showButton?: boolean
 }

--- a/components/Token/Card.tsx
+++ b/components/Token/Card.tsx
@@ -53,14 +53,12 @@ export type Props = {
     } | null
     quantity: string
     bestBid: {
-      nodes: {
-        unitPrice: string
-        currency: {
-          decimals: number
-          symbol: string
-        }
-      }[]
-    }
+      unitPrice: string
+      currency: {
+        decimals: number
+        symbol: string
+      }
+    } | null
     firstSale:
       | {
           totalCount: number
@@ -92,8 +90,7 @@ const TokenCard: FC<Props> = ({ asset }) => {
   const media = useDetectAssetMedia(asset)
 
   const sale = asset.firstSale?.nodes[0]
-  const bestBid =
-    asset.bestBid?.nodes?.length > 0 ? asset.bestBid.nodes[0] : undefined
+  const bestBid = asset.bestBid
   const numberOfSales = asset.firstSale?.totalCount || 0
   const hasMultiCurrency = asset.firstSale?.totalCurrencyDistinctCount
     ? asset.firstSale.totalCurrencyDistinctCount > 1

--- a/components/Token/Card.tsx
+++ b/components/Token/Card.tsx
@@ -59,23 +59,19 @@ export type Props = {
         symbol: string
       }
     } | null
-    firstSale:
-      | {
-          totalCount: number
-          totalCurrencyDistinctCount: number
-          nodes: {
-            id: string
-            unitPrice: string
-            currency: {
-              decimals: number
-              symbol: string
-            }
-            maker: {
-              address: string
-            }
-          }[]
-        }
-      | undefined
+    firstSale: {
+      id: string
+      unitPrice: string
+      currency: {
+        decimals: number
+        symbol: string
+      }
+      maker: {
+        address: string
+      }
+    } | null
+    totalSalesCount: number
+    totalSalesCurrencyDistinctCount: number
   }
 }
 
@@ -89,12 +85,10 @@ const TokenCard: FC<Props> = ({ asset }) => {
   const [isHovered, setIsHovered] = useState(false)
   const media = useDetectAssetMedia(asset)
 
-  const sale = asset.firstSale?.nodes[0]
+  const sale = asset.firstSale
   const bestBid = asset.bestBid
-  const numberOfSales = asset.firstSale?.totalCount || 0
-  const hasMultiCurrency = asset.firstSale?.totalCurrencyDistinctCount
-    ? asset.firstSale.totalCurrencyDistinctCount > 1
-    : false
+  const numberOfSales = asset.totalSalesCount
+  const hasMultiCurrency = asset.totalSalesCurrencyDistinctCount > 1
   const chainName = useMemo(
     () => CHAINS.find((x) => x.id === asset.collection.chainId)?.name,
     [asset.collection.chainId, CHAINS],

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@graphql-codegen/typescript-react-apollo": "^4.1.0",
         "@graphql-eslint/eslint-plugin": "^3.20.1",
         "@next/bundle-analyzer": "^14.0.4",
-        "@nft/api-graphql": "^1.0.0-beta.51",
+        "@nft/api-graphql": "^1.0.0-beta.52-prerelease-3",
         "@types/nodemailer": "^6.4.14",
         "@types/nprogress": "^0.2.3",
         "@types/react": "^18.2.48",
@@ -6724,9 +6724,9 @@
       }
     },
     "node_modules/@nft/api-graphql": {
-      "version": "1.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.51.tgz",
-      "integrity": "sha512-IBpOGh0Xmu6CFQZqYTwVAahut/WiphjcsDT82td8xSpmwsE0AADIxZ97OP4cclDGBVVhX7bSvsQFge5HxCzxyA==",
+      "version": "1.0.0-beta.52-prerelease-3",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52-prerelease-3.tgz",
+      "integrity": "sha512-FCYJOEb3V9GdM/6AIlJi/AS31Ia6/MnDpq3SxnofDsEhPD8IppRVmBKf0j8hejdL/CHVsNZwnRKsYsGTleVaGA==",
       "dev": true
     },
     "node_modules/@nft/chat": {
@@ -26699,9 +26699,9 @@
       "optional": true
     },
     "@nft/api-graphql": {
-      "version": "1.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.51.tgz",
-      "integrity": "sha512-IBpOGh0Xmu6CFQZqYTwVAahut/WiphjcsDT82td8xSpmwsE0AADIxZ97OP4cclDGBVVhX7bSvsQFge5HxCzxyA==",
+      "version": "1.0.0-beta.52-prerelease-3",
+      "resolved": "https://registry.npmjs.org/@nft/api-graphql/-/api-graphql-1.0.0-beta.52-prerelease-3.tgz",
+      "integrity": "sha512-FCYJOEb3V9GdM/6AIlJi/AS31Ia6/MnDpq3SxnofDsEhPD8IppRVmBKf0j8hejdL/CHVsNZwnRKsYsGTleVaGA==",
       "dev": true
     },
     "@nft/chat": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@graphql-codegen/typescript-react-apollo": "^4.1.0",
     "@graphql-eslint/eslint-plugin": "^3.20.1",
     "@next/bundle-analyzer": "^14.0.4",
-    "@nft/api-graphql": "^1.0.0-beta.51",
+    "@nft/api-graphql": "^1.0.0-beta.52-prerelease-3",
     "@types/nodemailer": "^6.4.14",
     "@types/nprogress": "^0.2.3",
     "@types/react": "^18.2.48",

--- a/pages/checkout/[id].gql
+++ b/pages/checkout/[id].gql
@@ -1,4 +1,4 @@
-query Checkout($id: UUID!, $address: Address, $now: Datetime!) {
+query Checkout($id: UUID!, $address: Address) {
   offer(id: $id) {
     id
     type
@@ -40,28 +40,22 @@ query Checkout($id: UUID!, $address: Address, $now: Datetime!) {
           symbol
         }
       }
-      firstSale: sales(
-        first: 1
-        orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-      ) {
-        totalCount
-        totalCurrencyDistinctCount
-        nodes {
+      firstSale {
+        id
+        unitPrice
+        currency {
+          image
+          name
           id
-          unitPrice
-          currency {
-            image
-            name
-            id
-            decimals
-            symbol
-          }
-          maker {
-            address
-          }
+          decimals
+          symbol
+        }
+        maker {
+          address
         }
       }
+      totalSalesCount
+      totalSalesCurrencyDistinctCount
     }
     maker {
       address

--- a/pages/checkout/[id].gql
+++ b/pages/checkout/[id].gql
@@ -29,21 +29,15 @@ query Checkout($id: UUID!, $address: Address, $now: Datetime!) {
         quantity
       }
       quantity
-      bestBid: bids(
-        orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-        first: 1
-      ) {
-        nodes {
-          unitPrice
-          amount
-          currency {
-            image
-            name
-            id
-            decimals
-            symbol
-          }
+      bestBid {
+        unitPrice
+        amount
+        currency {
+          image
+          name
+          id
+          decimals
+          symbol
         }
       }
       firstSale: sales(

--- a/pages/checkout/[id].tsx
+++ b/pages/checkout/[id].tsx
@@ -28,11 +28,7 @@ import useRequiredQueryParamSingle from '../../hooks/useRequiredQueryParamSingle
 import SmallLayout from '../../layouts/small'
 import Error from '../_error'
 
-type Props = {
-  now: string
-}
-
-const CheckoutPage: NextPage<Props> = ({ now }) => {
+const CheckoutPage: NextPage = () => {
   const { t } = useTranslation('templates')
   const { back, push } = useRouter()
   const toast = useToast()
@@ -40,12 +36,10 @@ const CheckoutPage: NextPage<Props> = ({ now }) => {
 
   const { address } = useAccount()
 
-  const date = useMemo(() => new Date(now), [now])
   const { data: offerData } = useCheckoutQuery({
     variables: {
       id: offerId,
       address: address || '',
-      now: date,
     },
   })
   const offer = offerData?.offer

--- a/pages/collection/[chainId]/[id]/index.gql
+++ b/pages/collection/[chainId]/[id]/index.gql
@@ -50,7 +50,6 @@ query FetchCollectionMetrics($collectionAddress: Address!, $chainId: Int!) {
 
 query FetchCollectionAssets(
   $currentAccount: Address!
-  $now: Datetime!
   $offset: Int!
   $limit: Int!
   $chainId: Int!
@@ -114,27 +113,22 @@ query FetchCollectionAssets(
           symbol
         }
       }
-      firstSale: sales(
-        first: 1
-        orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-      ) {
-        totalCount
-        totalCurrencyDistinctCount
-        nodes {
+      firstSale {
+        id
+        unitPrice
+        currency {
+          image
+          name
           id
-          unitPrice
-          currency {
-            image
-            id
-            decimals
-            symbol
-          }
-          maker {
-            address
-          }
+          decimals
+          symbol
+        }
+        maker {
+          address
         }
       }
+      totalSalesCount
+      totalSalesCurrencyDistinctCount
     }
   }
 }

--- a/pages/collection/[chainId]/[id]/index.gql
+++ b/pages/collection/[chainId]/[id]/index.gql
@@ -103,21 +103,15 @@ query FetchCollectionAssets(
         quantity
       }
       quantity
-      bestBid: bids(
-        orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-        first: 1
-      ) {
-        nodes {
-          unitPrice
-          amount
-          currency {
-            image
-            name
-            id
-            decimals
-            symbol
-          }
+      bestBid {
+        unitPrice
+        amount
+        currency {
+          image
+          name
+          id
+          decimals
+          symbol
         }
       }
       firstSale: sales(

--- a/pages/collection/[chainId]/[id]/index.tsx
+++ b/pages/collection/[chainId]/[id]/index.tsx
@@ -91,7 +91,6 @@ const CollectionPage: FC<Props> = ({ now }) => {
   const { data: assetData } = useFetchCollectionAssetsQuery({
     variables: {
       collectionAddress,
-      now: date,
       currentAccount: address || '',
       limit,
       offset,

--- a/pages/create/[chainId]/[collectionAddress].tsx
+++ b/pages/create/[chainId]/[collectionAddress].tsx
@@ -137,7 +137,7 @@ const CreatePage: NextPage = () => {
                 asset={{
                   ...asset,
                   creator,
-                  bestBid: { nodes: [] },
+                  bestBid: null,
                   firstSale: undefined,
                 }}
               />

--- a/pages/create/[chainId]/[collectionAddress].tsx
+++ b/pages/create/[chainId]/[collectionAddress].tsx
@@ -138,7 +138,9 @@ const CreatePage: NextPage = () => {
                   ...asset,
                   creator,
                   bestBid: null,
-                  firstSale: undefined,
+                  firstSale: null,
+                  totalSalesCount: 0,
+                  totalSalesCurrencyDistinctCount: 0,
                 }}
               />
             )}

--- a/pages/explore/explore.gql
+++ b/pages/explore/explore.gql
@@ -1,5 +1,4 @@
 query FetchAllERC721And1155(
-  $now: Datetime!
   $address: Address
   $limit: Int!
   $offset: Int!
@@ -45,28 +44,22 @@ query FetchAllERC721And1155(
           symbol
         }
       }
-      firstSale: sales(
-        first: 1
-        orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-      ) {
-        totalCount
-        totalCurrencyDistinctCount
-        nodes {
+      firstSale {
+        id
+        unitPrice
+        currency {
+          image
+          name
           id
-          unitPrice
-          currency {
-            image
-            name
-            id
-            decimals
-            symbol
-          }
-          maker {
-            address
-          }
+          decimals
+          symbol
+        }
+        maker {
+          address
         }
       }
+      totalSalesCount
+      totalSalesCurrencyDistinctCount
       creator {
         address
         name

--- a/pages/explore/explore.gql
+++ b/pages/explore/explore.gql
@@ -34,21 +34,15 @@ query FetchAllERC721And1155(
         quantity
       }
       quantity
-      bestBid: bids(
-        orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-        filter: { expiredAt: { greaterThan: $now } }
-        first: 1
-      ) {
-        nodes {
-          unitPrice
-          amount
-          currency {
-            image
-            name
-            id
-            decimals
-            symbol
-          }
+      bestBid {
+        unitPrice
+        amount
+        currency {
+          image
+          name
+          id
+          decimals
+          symbol
         }
       }
       firstSale: sales(

--- a/pages/explore/explore.tsx
+++ b/pages/explore/explore.tsx
@@ -59,7 +59,6 @@ const ExplorePage: NextPage<Props> = ({ now }) => {
   const { page, limit, offset } = usePaginateQuery()
   const { data: assetsData, refetch } = useFetchAllErc721And1155Query({
     variables: {
-      now: date,
       address: address || '',
       limit,
       offset,

--- a/pages/tokens/[id]/bid.gql
+++ b/pages/tokens/[id]/bid.gql
@@ -3,7 +3,6 @@ query BidOnAsset(
   $collectionAddress: Address!
   $tokenId: String!
   $address: Address
-  $now: Datetime!
 ) {
   asset(
     chainId: $chainId
@@ -47,28 +46,22 @@ query BidOnAsset(
         symbol
       }
     }
-    firstSale: sales(
-      first: 1
-      orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-      filter: { expiredAt: { greaterThan: $now } }
-    ) {
-      totalCount
-      totalCurrencyDistinctCount
-      nodes {
+    firstSale {
+      id
+      unitPrice
+      currency {
+        image
+        name
         id
-        unitPrice
-        currency {
-          image
-          name
-          id
-          decimals
-          symbol
-        }
-        maker {
-          address
-        }
+        decimals
+        symbol
+      }
+      maker {
+        address
       }
     }
+    totalSalesCount
+    totalSalesCurrencyDistinctCount
   }
   currencies(
     orderBy: CREATED_AT_ASC

--- a/pages/tokens/[id]/bid.gql
+++ b/pages/tokens/[id]/bid.gql
@@ -36,21 +36,15 @@ query BidOnAsset(
     owned: ownership(ownerAddress: $address) {
       quantity
     }
-    bestBid: bids(
-      orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-      filter: { expiredAt: { greaterThan: $now } }
-      first: 1
-    ) {
-      nodes {
-        unitPrice
-        amount
-        currency {
-          image
-          name
-          id
-          decimals
-          symbol
-        }
+    bestBid {
+      unitPrice
+      amount
+      currency {
+        image
+        name
+        id
+        decimals
+        symbol
       }
     }
     firstSale: sales(

--- a/pages/tokens/[id]/bid.tsx
+++ b/pages/tokens/[id]/bid.tsx
@@ -16,11 +16,7 @@ import useRequiredQueryParamSingle from '../../../hooks/useRequiredQueryParamSin
 import SmallLayout from '../../../layouts/small'
 import Error from '../../_error'
 
-type Props = {
-  now: string
-}
-
-const BidPage: NextPage<Props> = ({ now }) => {
+const BidPage: NextPage = () => {
   const { t } = useTranslation('templates')
   const { back, push } = useRouter()
   const toast = useToast()
@@ -32,13 +28,11 @@ const BidPage: NextPage<Props> = ({ now }) => {
   )
   invariant(chainId && collectionAddress && tokenId, 'Invalid asset id')
 
-  const date = useMemo(() => new Date(now), [now])
   const { data } = useBidOnAssetQuery({
     variables: {
       chainId: parseInt(chainId, 10),
       collectionAddress: collectionAddress,
       tokenId: tokenId,
-      now: date,
       address: address || '',
     },
   })

--- a/pages/tokens/[id]/offer.gql
+++ b/pages/tokens/[id]/offer.gql
@@ -3,7 +3,6 @@ query OfferForAsset(
   $collectionAddress: Address!
   $tokenId: String!
   $address: Address
-  $now: Datetime!
 ) {
   asset(
     chainId: $chainId
@@ -42,28 +41,22 @@ query OfferForAsset(
         symbol
       }
     }
-    firstSale: sales(
-      first: 1
-      orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-      filter: { expiredAt: { greaterThan: $now } }
-    ) {
-      totalCount
-      totalCurrencyDistinctCount
-      nodes {
+    firstSale {
+      id
+      unitPrice
+      currency {
+        image
+        name
         id
-        unitPrice
-        currency {
-          image
-          name
-          id
-          decimals
-          symbol
-        }
-        maker {
-          address
-        }
+        decimals
+        symbol
+      }
+      maker {
+        address
       }
     }
+    totalSalesCount
+    totalSalesCurrencyDistinctCount
     creator {
       address
       name

--- a/pages/tokens/[id]/offer.gql
+++ b/pages/tokens/[id]/offer.gql
@@ -31,21 +31,15 @@ query OfferForAsset(
       quantity
     }
     quantity
-    bestBid: bids(
-      orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-      filter: { expiredAt: { greaterThan: $now } }
-      first: 1
-    ) {
-      nodes {
-        unitPrice
-        amount
-        currency {
-          image
-          name
-          id
-          decimals
-          symbol
-        }
+    bestBid {
+      unitPrice
+      amount
+      currency {
+        image
+        name
+        id
+        decimals
+        symbol
       }
     }
     firstSale: sales(

--- a/pages/tokens/[id]/offer.tsx
+++ b/pages/tokens/[id]/offer.tsx
@@ -19,7 +19,6 @@ import Error from '../../_error'
 
 type Props = {
   assetId: string
-  now: string
   currentAccount: string | null
   meta: {
     title: string
@@ -28,7 +27,7 @@ type Props = {
   }
 }
 
-const OfferPage: NextPage<Props> = ({ now }) => {
+const OfferPage: NextPage<Props> = () => {
   const { t } = useTranslation('templates')
   const { back, push } = useRouter()
   const toast = useToast()
@@ -41,13 +40,11 @@ const OfferPage: NextPage<Props> = ({ now }) => {
   )
   invariant(chainId && collectionAddress && tokenId, 'Invalid asset id')
 
-  const date = useMemo(() => new Date(now), [now])
   const { data } = useOfferForAssetQuery({
     variables: {
       chainId: parseInt(chainId, 10),
       collectionAddress: collectionAddress,
       tokenId: tokenId,
-      now: date,
       address: address || '',
     },
   })

--- a/pages/users/[id]/assetDetail.gql
+++ b/pages/users/[id]/assetDetail.gql
@@ -26,27 +26,22 @@ fragment AssetDetail on Asset {
       symbol
     }
   }
-  firstSale: sales(
-    first: 1
-    orderBy: [UNIT_PRICE_IN_REF_ASC, CREATED_AT_ASC]
-    filter: { expiredAt: { greaterThan: $now } }
-  ) {
-    totalCount
-    totalCurrencyDistinctCount
-    nodes {
+  firstSale {
+    id
+    unitPrice
+    currency {
+      image
+      name
       id
-      unitPrice
-      currency {
-        image
-        id
-        decimals
-        symbol
-      }
-      maker {
-        address
-      }
+      decimals
+      symbol
+    }
+    maker {
+      address
     }
   }
+  totalSalesCount
+  totalSalesCurrencyDistinctCount
   creator {
     address
     name

--- a/pages/users/[id]/assetDetail.gql
+++ b/pages/users/[id]/assetDetail.gql
@@ -15,21 +15,15 @@ fragment AssetDetail on Asset {
   imageMimetype
   animationUrl
   animationMimetype
-  bestBid: bids(
-    orderBy: [UNIT_PRICE_IN_REF_DESC, CREATED_AT_ASC]
-    filter: { expiredAt: { greaterThan: $now } }
-    first: 1
-  ) {
-    nodes {
-      unitPrice
-      amount
-      currency {
-        image
-        name
-        id
-        decimals
-        symbol
-      }
+  bestBid {
+    unitPrice
+    amount
+    currency {
+      image
+      name
+      id
+      decimals
+      symbol
     }
   }
   firstSale: sales(

--- a/pages/users/[id]/created.gql
+++ b/pages/users/[id]/created.gql
@@ -1,7 +1,6 @@
 query FetchCreatedAssets(
   $address: Address!
   $currentAddress: Address!
-  $now: Datetime!
   $limit: Int!
   $offset: Int!
   $orderBy: [AssetsOrderBy!]

--- a/pages/users/[id]/created.tsx
+++ b/pages/users/[id]/created.tsx
@@ -13,11 +13,7 @@ import usePaginateQuery from '../../../hooks/usePaginateQuery'
 import useRequiredQueryParamSingle from '../../../hooks/useRequiredQueryParamSingle'
 import LargeLayout from '../../../layouts/large'
 
-type Props = {
-  now: string
-}
-
-const CreatedPage: NextPage<Props> = ({ now }) => {
+const CreatedPage: NextPage = () => {
   const { PAGINATION_LIMIT, BASE_URL } = useEnvironment()
   const { t } = useTranslation('templates')
   const { pathname, replace, query } = useRouter()
@@ -27,7 +23,6 @@ const CreatedPage: NextPage<Props> = ({ now }) => {
   const { address } = useAccount()
   const userAddress = useRequiredQueryParamSingle('id')
 
-  const date = useMemo(() => new Date(now), [now])
   const { data } = useFetchCreatedAssetsQuery({
     variables: {
       address: userAddress,
@@ -35,7 +30,6 @@ const CreatedPage: NextPage<Props> = ({ now }) => {
       limit,
       offset,
       orderBy,
-      now: date,
     },
   })
 

--- a/pages/users/[id]/owned.gql
+++ b/pages/users/[id]/owned.gql
@@ -1,7 +1,6 @@
 query FetchOwnedAssets(
   $address: Address!
   $currentAddress: Address!
-  $now: Datetime!
   $limit: Int!
   $offset: Int!
   $orderBy: [OwnershipsOrderBy!]

--- a/pages/users/[id]/owned.tsx
+++ b/pages/users/[id]/owned.tsx
@@ -18,11 +18,7 @@ import usePaginateQuery from '../../../hooks/usePaginateQuery'
 import useRequiredQueryParamSingle from '../../../hooks/useRequiredQueryParamSingle'
 import LargeLayout from '../../../layouts/large'
 
-type Props = {
-  now: string
-}
-
-const OwnedPage: NextPage<Props> = ({ now }) => {
+const OwnedPage: NextPage = () => {
   const { PAGINATION_LIMIT, BASE_URL } = useEnvironment()
   const { t } = useTranslation('templates')
   const { pathname, replace, query } = useRouter()
@@ -32,7 +28,6 @@ const OwnedPage: NextPage<Props> = ({ now }) => {
   const { address } = useAccount()
   const userAddress = useRequiredQueryParamSingle('id')
 
-  const date = useMemo(() => new Date(now), [now])
   const { data, refetch } = useFetchOwnedAssetsQuery({
     variables: {
       address: userAddress,
@@ -40,7 +35,6 @@ const OwnedPage: NextPage<Props> = ({ now }) => {
       limit,
       offset,
       orderBy,
-      now: date,
     },
   })
 


### PR DESCRIPTION
### Description

- Use `bestBid` resolver on asset instead of bids connection
- Use `firstSale`, `totalSalesCount`, `totalSalesCurrencyDistinctCount` resolvers on asset instead of sales connection

~~Need update of API before merging this PR.~~

### Checklist

- [x] Base branch of the PR is `dev`