### PR TITLE
Add Cache-Control header

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -64,6 +64,16 @@ class MyDocument extends Document {
   ): Promise<DocumentInitialProps & MyDocumentProps> {
     invariant(context.req)
     const jwt = context.req?.cookies?.[COOKIE_JWT_TOKEN] || null
+
+    // set cache control header
+    context.res?.setHeader(
+      'Cache-Control',
+      `${
+        // make the cache private if user is logged in
+        jwt ? 'private' : 'public'
+      }, max-age=10, stale-while-revalidate=10`,
+    )
+
     const environment = await getEnvironment()
     // the `getClient` needs to be reset on every request as early as possible and before any rendering
     const apolloClient = getClient(


### PR DESCRIPTION
### Description

Add Cache-Control header to allow Vercel to cache the server-side generated HTML.

With this, when a page is cached, subsequent users will get this cached page.
When the cache expires after 10sec, Vercel still returns the cached page if it is less than 10sec expired but also update it in the background (`stale-while-revalidate`). So when there is at least one loading of the page every 20sec, users should always get a cached version that is max 20sec old.

This cache is only saved when the user is not logged in. But logged in users will get a "public" cache version if one exist. I didn't find a way to disable this. The page is flickering on component that are loading user-specific data.

### How to test

- Open a new tab
- Open the network console
- Go to `https://nft-test-uaan-git-feature-cache-liteflow.vercel.app/`
- Check  the `Cache-Control` and `Age` headers of the first response
- Hard refresh (no local cache) the page, notice the faster speed and the headers

### Checklist

- [x] Base branch of the PR is `dev`