### PR TITLE
use Blockscount instead of Neon scan for Neon mainnet and devnet

### DIFF
--- a/environment.ts
+++ b/environment.ts
@@ -241,7 +241,24 @@ const getEnvironment = async (): Promise<Environment> => {
       bsc,
       polygon,
       polygonMumbai,
-      neonMainnet,
+      {
+        ...neonMainnet,
+        blockExplorers: {
+          default: {
+            name: 'Blockscout',
+            url: 'https://neon.blockscout.com',
+          },
+        },
+      },
+      {
+        ...neonDevnet,
+        blockExplorers: {
+          default: {
+            name: 'Blockscout',
+            url: 'https://neon-devnet.blockscout.com',
+          },
+        },
+      },
       neonDevnet,
       arbitrum,
       arbitrumSepolia,

--- a/environment.ts
+++ b/environment.ts
@@ -259,7 +259,6 @@ const getEnvironment = async (): Promise<Environment> => {
           },
         },
       },
-      neonDevnet,
       arbitrum,
       arbitrumSepolia,
       {


### PR DESCRIPTION
use Blockscount instead of Neon scan for Neon mainnet and devnet
