### PR TITLE
v3.6.1

### DIFF
--- a/components/Offer/Summary.tsx
+++ b/components/Offer/Summary.tsx
@@ -66,7 +66,7 @@ const Summary: FC<Props> = ({
           ) : (
             <Heading as={Flex} variant="heading3" color="gray.500" mb={2}>
               {t('offer.summary.fees', {
-                value: feesOnTopPerTenThousand.div(100).toString(),
+                value: parseFloat(feesOnTopPerTenThousand.toString()) / 100,
               })}
               <Text
                 as={Price}

--- a/components/Sales/Direct/Form.tsx
+++ b/components/Sales/Direct/Form.tsx
@@ -408,7 +408,7 @@ const SalesDirectForm: FC<Props> = ({ asset, currencies, onCreated }) => {
             ) : (
               <Text variant="text" color="gray.500">
                 {t('sales.direct.form.fees', {
-                  value: feesPerTenThousand.div(100).toString(),
+                  value: parseFloat(feesPerTenThousand.toString()) / 100,
                 })}
                 <Text
                   as={Price}
@@ -481,7 +481,7 @@ const SalesDirectForm: FC<Props> = ({ asset, currencies, onCreated }) => {
             ) : (
               <Text variant="text" color="gray.500">
                 {t('sales.direct.form.total-fees', {
-                  value: feesPerTenThousand.div(100).toString(),
+                  value: parseFloat(feesPerTenThousand.toString()) / 100,
                 })}
                 <Text
                   as={Price}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starter-kit",
-  "version": "2.1.1",
+  "version": "3.6.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .next",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starter-kit",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "private": true,
   "scripts": {
     "clean": "rimraf .next",


### PR DESCRIPTION
This pull request includes updates to the handling of fee values in the `Summary` and `SalesDirectForm` components, as well as a version bump in the `package.json` file.

Updates to fee value handling:

* [`components/Offer/Summary.tsx`](diffhunk://#diff-ac4ae86b67ebd761929e17ce69d32a209ac7f884438598961a8dcdf5ba9099e8L69-R69): Changed the way fees are calculated by using `parseFloat` to convert `feesOnTopPerTenThousand` to a number before dividing by 100.
* [`components/Sales/Direct/Form.tsx`](diffhunk://#diff-6cb7f87b902446a897b67bd2b90b8e6dece7cce8b35ad444d796a0926270fb97L411-R411): Updated the calculation of `feesPerTenThousand` and `total-fees` to use `parseFloat` before dividing by 100 for accurate fee representation. [[1]](diffhunk://#diff-6cb7f87b902446a897b67bd2b90b8e6dece7cce8b35ad444d796a0926270fb97L411-R411) [[2]](diffhunk://#diff-6cb7f87b902446a897b67bd2b90b8e6dece7cce8b35ad444d796a0926270fb97L484-R484)

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the project version from `3.6.0` to `3.6.1`.