### PR TITLE
Add Alchemy info to BSC chains

### DIFF
--- a/environment.ts
+++ b/environment.ts
@@ -241,8 +241,26 @@ const getEnvironment = async (): Promise<Environment> => {
     CHAINS: [
       ethereumMainnet,
       ethereumSepolia,
-      bscTestnet,
-      bsc,
+      {
+        ...bsc,
+        rpcUrls: {
+          ...bsc.rpcUrls,
+          alchemy: {
+            http: ['https://bnb-mainnet.g.alchemy.com/v2'],
+            webSocket: ['wss://bnb-mainnet.g.alchemy.com/v2'],
+          },
+        },
+      },
+      {
+        ...bscTestnet,
+        rpcUrls: {
+          ...bscTestnet.rpcUrls,
+          alchemy: {
+            http: ['https://bnb-testnet.g.alchemy.com/v2'],
+            webSocket: ['wss://bnb-testnet.g.alchemy.com/v2'],
+          },
+        },
+      },
       polygon,
       {
         id: 80_002,


### PR DESCRIPTION
### Description

Add Alchemy info to BSC chains to allow falling back to Alchemy when public provider is not working.

### Checklist

- [x] Base branch of the PR is `dev`
