### PR TITLE
add support for html media

### DIFF
--- a/components/Token/Media.tsx
+++ b/components/Token/Media.tsx
@@ -12,7 +12,12 @@ import { FC, useCallback, useEffect, useState } from 'react'
 import { AssetMedia } from '../../hooks/useDetectAssetMedia'
 import Image from '../Image/Image'
 
-const supportedMedia = [/^image\/*/, /^video\/*/, /^application\/octet-stream$/]
+const supportedMedia = [
+  /^image\/*/,
+  /^video\/*/,
+  /^application\/octet-stream$/,
+  /^text\/html$/,
+]
 
 const TokenMedia: FC<{
   media: AssetMedia
@@ -74,6 +79,15 @@ const TokenMedia: FC<{
         </Center>
       </>
     )
+
+  // display html
+  if (mediaToDisplay.mimetype === 'text/html') {
+    return (
+      <Box position="relative" w="full" h="full">
+        <iframe src={mediaToDisplay.url} width="100%" height="100%" />
+      </Box>
+    )
+  }
 
   // display video
   if (


### PR DESCRIPTION
Add support for html media files embedded in an iframe

This allows to load nfts like https://marketplace-demo.liteflow.com/tokens/97-0xaade84b6a5f76c0a5f7ae91e65197329eb23763f-34081265737503256337038727118962159868999502952850461792383585871355429799494
